### PR TITLE
feat: YAML 설정 파싱 구현

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,28 @@
+proxy:
+  listen: "0.0.0.0:5432"
+
+writer:
+  host: "primary.db.internal"
+  port: 5432
+
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+  - host: "replica-2.db.internal"
+    port: 5432
+
+pool:
+  min_connections: 5
+  max_connections: 50
+  idle_timeout: 10m
+  max_lifetime: 1h
+  connection_timeout: 5s
+
+routing:
+  read_after_write_delay: 500ms
+
+cache:
+  enabled: true
+  cache_ttl: 10s
+  max_cache_entries: 10000
+  max_result_size: "1MB"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jyukki97/db-proxy
 
 go 1.25.1
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Proxy   ProxyConfig   `yaml:"proxy"`
+	Writer  DBConfig      `yaml:"writer"`
+	Readers []DBConfig    `yaml:"readers"`
+	Pool    PoolConfig    `yaml:"pool"`
+	Routing RoutingConfig `yaml:"routing"`
+	Cache   CacheConfig   `yaml:"cache"`
+}
+
+type ProxyConfig struct {
+	Listen string `yaml:"listen"`
+}
+
+type DBConfig struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
+type PoolConfig struct {
+	MinConnections    int           `yaml:"min_connections"`
+	MaxConnections    int           `yaml:"max_connections"`
+	IdleTimeout       time.Duration `yaml:"idle_timeout"`
+	MaxLifetime       time.Duration `yaml:"max_lifetime"`
+	ConnectionTimeout time.Duration `yaml:"connection_timeout"`
+}
+
+type RoutingConfig struct {
+	ReadAfterWriteDelay time.Duration `yaml:"read_after_write_delay"`
+}
+
+type CacheConfig struct {
+	Enabled        bool          `yaml:"enabled"`
+	CacheTTL       time.Duration `yaml:"cache_ttl"`
+	MaxCacheEntries int          `yaml:"max_cache_entries"`
+	MaxResultSize   string       `yaml:"max_result_size"`
+}
+
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoad(t *testing.T) {
+	content := `
+proxy:
+  listen: "0.0.0.0:5432"
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+  - host: "replica-2.db.internal"
+    port: 5432
+pool:
+  min_connections: 5
+  max_connections: 50
+  idle_timeout: 10m
+  max_lifetime: 1h
+  connection_timeout: 5s
+routing:
+  read_after_write_delay: 500ms
+cache:
+  enabled: true
+  cache_ttl: 10s
+  max_cache_entries: 10000
+  max_result_size: "1MB"
+`
+
+	tmpFile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	cfg, err := Load(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Proxy
+	if cfg.Proxy.Listen != "0.0.0.0:5432" {
+		t.Errorf("Proxy.Listen = %q, want %q", cfg.Proxy.Listen, "0.0.0.0:5432")
+	}
+
+	// Writer
+	if cfg.Writer.Host != "primary.db.internal" {
+		t.Errorf("Writer.Host = %q, want %q", cfg.Writer.Host, "primary.db.internal")
+	}
+	if cfg.Writer.Port != 5432 {
+		t.Errorf("Writer.Port = %d, want %d", cfg.Writer.Port, 5432)
+	}
+
+	// Readers
+	if len(cfg.Readers) != 2 {
+		t.Fatalf("len(Readers) = %d, want 2", len(cfg.Readers))
+	}
+	if cfg.Readers[0].Host != "replica-1.db.internal" {
+		t.Errorf("Readers[0].Host = %q, want %q", cfg.Readers[0].Host, "replica-1.db.internal")
+	}
+
+	// Pool
+	if cfg.Pool.MinConnections != 5 {
+		t.Errorf("Pool.MinConnections = %d, want 5", cfg.Pool.MinConnections)
+	}
+	if cfg.Pool.MaxConnections != 50 {
+		t.Errorf("Pool.MaxConnections = %d, want 50", cfg.Pool.MaxConnections)
+	}
+	if cfg.Pool.IdleTimeout != 10*time.Minute {
+		t.Errorf("Pool.IdleTimeout = %v, want 10m", cfg.Pool.IdleTimeout)
+	}
+	if cfg.Pool.MaxLifetime != time.Hour {
+		t.Errorf("Pool.MaxLifetime = %v, want 1h", cfg.Pool.MaxLifetime)
+	}
+	if cfg.Pool.ConnectionTimeout != 5*time.Second {
+		t.Errorf("Pool.ConnectionTimeout = %v, want 5s", cfg.Pool.ConnectionTimeout)
+	}
+
+	// Routing
+	if cfg.Routing.ReadAfterWriteDelay != 500*time.Millisecond {
+		t.Errorf("Routing.ReadAfterWriteDelay = %v, want 500ms", cfg.Routing.ReadAfterWriteDelay)
+	}
+
+	// Cache
+	if !cfg.Cache.Enabled {
+		t.Error("Cache.Enabled = false, want true")
+	}
+	if cfg.Cache.CacheTTL != 10*time.Second {
+		t.Errorf("Cache.CacheTTL = %v, want 10s", cfg.Cache.CacheTTL)
+	}
+	if cfg.Cache.MaxCacheEntries != 10000 {
+		t.Errorf("Cache.MaxCacheEntries = %d, want 10000", cfg.Cache.MaxCacheEntries)
+	}
+	if cfg.Cache.MaxResultSize != "1MB" {
+		t.Errorf("Cache.MaxResultSize = %q, want %q", cfg.Cache.MaxResultSize, "1MB")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load("nonexistent.yaml")
+	if err == nil {
+		t.Error("Load() expected error for missing file, got nil")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString("invalid: yaml: [broken"); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	_, err = Load(tmpFile.Name())
+	if err == nil {
+		t.Error("Load() expected error for invalid YAML, got nil")
+	}
+}


### PR DESCRIPTION
## 변경 사항
- `internal/config/config.go`: Config 구조체 정의 및 `Load()` 함수
- `config.yaml`: 기본 설정 파일
- 단위 테스트 3건 (정상 파싱, 파일 없음, 잘못된 YAML)

## 테스트
- `go test ./internal/config/ -v` → 3/3 PASS

closes #3