### PR TITLE
feat: 설정 validation 추가

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,5 +56,74 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
+	cfg.applyDefaults()
+
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
 	return &cfg, nil
+}
+
+func (c *Config) applyDefaults() {
+	if c.Proxy.Listen == "" {
+		c.Proxy.Listen = "0.0.0.0:5432"
+	}
+	if c.Pool.MinConnections == 0 {
+		c.Pool.MinConnections = 2
+	}
+	if c.Pool.MaxConnections == 0 {
+		c.Pool.MaxConnections = 10
+	}
+	if c.Pool.IdleTimeout == 0 {
+		c.Pool.IdleTimeout = 10 * time.Minute
+	}
+	if c.Pool.MaxLifetime == 0 {
+		c.Pool.MaxLifetime = time.Hour
+	}
+	if c.Pool.ConnectionTimeout == 0 {
+		c.Pool.ConnectionTimeout = 5 * time.Second
+	}
+	if c.Routing.ReadAfterWriteDelay == 0 {
+		c.Routing.ReadAfterWriteDelay = 500 * time.Millisecond
+	}
+	if c.Cache.CacheTTL == 0 {
+		c.Cache.CacheTTL = 10 * time.Second
+	}
+	if c.Cache.MaxCacheEntries == 0 {
+		c.Cache.MaxCacheEntries = 10000
+	}
+	if c.Cache.MaxResultSize == "" {
+		c.Cache.MaxResultSize = "1MB"
+	}
+}
+
+func (c *Config) validate() error {
+	if c.Writer.Host == "" {
+		return fmt.Errorf("writer.host is required")
+	}
+	if c.Writer.Port <= 0 || c.Writer.Port > 65535 {
+		return fmt.Errorf("writer.port must be between 1 and 65535, got %d", c.Writer.Port)
+	}
+	if len(c.Readers) == 0 {
+		return fmt.Errorf("at least one reader is required")
+	}
+	for i, r := range c.Readers {
+		if r.Host == "" {
+			return fmt.Errorf("readers[%d].host is required", i)
+		}
+		if r.Port <= 0 || r.Port > 65535 {
+			return fmt.Errorf("readers[%d].port must be between 1 and 65535, got %d", i, r.Port)
+		}
+	}
+	if c.Pool.MinConnections < 0 {
+		return fmt.Errorf("pool.min_connections must be >= 0, got %d", c.Pool.MinConnections)
+	}
+	if c.Pool.MaxConnections < 1 {
+		return fmt.Errorf("pool.max_connections must be >= 1, got %d", c.Pool.MaxConnections)
+	}
+	if c.Pool.MinConnections > c.Pool.MaxConnections {
+		return fmt.Errorf("pool.min_connections (%d) must be <= pool.max_connections (%d)", c.Pool.MinConnections, c.Pool.MaxConnections)
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -131,3 +131,113 @@ func TestLoad_InvalidYAML(t *testing.T) {
 		t.Error("Load() expected error for invalid YAML, got nil")
 	}
 }
+
+func TestLoad_Defaults(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+`
+	cfg := loadFromString(t, content)
+
+	if cfg.Proxy.Listen != "0.0.0.0:5432" {
+		t.Errorf("default Proxy.Listen = %q, want %q", cfg.Proxy.Listen, "0.0.0.0:5432")
+	}
+	if cfg.Pool.MinConnections != 2 {
+		t.Errorf("default Pool.MinConnections = %d, want 2", cfg.Pool.MinConnections)
+	}
+	if cfg.Pool.MaxConnections != 10 {
+		t.Errorf("default Pool.MaxConnections = %d, want 10", cfg.Pool.MaxConnections)
+	}
+	if cfg.Pool.IdleTimeout != 10*time.Minute {
+		t.Errorf("default Pool.IdleTimeout = %v, want 10m", cfg.Pool.IdleTimeout)
+	}
+	if cfg.Cache.MaxResultSize != "1MB" {
+		t.Errorf("default Cache.MaxResultSize = %q, want %q", cfg.Cache.MaxResultSize, "1MB")
+	}
+}
+
+func TestLoad_Validation_MissingWriter(t *testing.T) {
+	content := `
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for missing writer host")
+	}
+}
+
+func TestLoad_Validation_NoReaders(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for no readers")
+	}
+}
+
+func TestLoad_Validation_MinGreaterThanMax(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+pool:
+  min_connections: 100
+  max_connections: 10
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for min > max connections")
+	}
+}
+
+func TestLoad_Validation_InvalidPort(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 99999
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for invalid writer port")
+	}
+}
+
+func loadFromString(t *testing.T, content string) *Config {
+	t.Helper()
+	cfg, err := loadFromStringRaw(t, content)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	return cfg
+}
+
+func loadFromStringRaw(t *testing.T, content string) (*Config, error) {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	return Load(tmpFile.Name())
+}


### PR DESCRIPTION
## 변경 사항
- `applyDefaults()`: listen, pool, routing, cache 기본값 자동 적용
- `validate()`: writer/reader 필수값, 포트 범위(1-65535), min/max 관계 검증
- validation 테스트 5건 추가

## 테스트
- `go test ./internal/config/ -v` → 8/8 PASS

closes #5