### PR TITLE
feat: TCP 리스너 구현

### DIFF
--- a/cmd/db-proxy/main.go
+++ b/cmd/db-proxy/main.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/jyukki97/db-proxy/internal/config"
+	"github.com/jyukki97/db-proxy/internal/proxy"
 )
 
 func main() {
@@ -13,6 +20,21 @@ func main() {
 }
 
 func run() error {
-	fmt.Println("db-proxy starting...")
-	return nil
+	cfgPath := "config.yaml"
+	if len(os.Args) > 1 {
+		cfgPath = os.Args[1]
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	srv := proxy.NewServer(cfg.Proxy.Listen)
+	slog.Info("db-proxy starting", "listen", cfg.Proxy.Listen)
+
+	return srv.Start(ctx)
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -1,0 +1,64 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+)
+
+type Server struct {
+	listenAddr string
+	listener   net.Listener
+	wg         sync.WaitGroup
+}
+
+func NewServer(listenAddr string) *Server {
+	return &Server{
+		listenAddr: listenAddr,
+	}
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	ln, err := net.Listen("tcp", s.listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.listenAddr, err)
+	}
+	s.listener = ln
+	slog.Info("proxy listening", "addr", s.listenAddr)
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				s.wg.Wait()
+				slog.Info("proxy shut down gracefully")
+				return nil
+			default:
+				slog.Error("accept connection", "error", err)
+				continue
+			}
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleConn(ctx, conn)
+		}()
+	}
+}
+
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	slog.Info("new connection", "remote", conn.RemoteAddr())
+
+	// TODO: PG 핸드셰이크 및 쿼리 릴레이 (T2-2, T2-3에서 구현)
+	<-ctx.Done()
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -1,0 +1,67 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestServer_AcceptsConnection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := NewServer("127.0.0.1:0")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.listener = ln
+	addr := ln.Addr().String()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			srv.wg.Add(1)
+			go func() {
+				defer srv.wg.Done()
+				srv.handleConn(ctx, conn)
+			}()
+		}
+	}()
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	conn.Close()
+
+	cancel()
+}
+
+func TestServer_GracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srv := NewServer("127.0.0.1:0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Start(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start() returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("shutdown timed out")
+	}
+}


### PR DESCRIPTION
## 변경 사항
- `internal/proxy/server.go`: TCP accept loop + graceful shutdown
- `cmd/db-proxy/main.go`: config 로드 → Server 시작 연결
- 테스트 2건 (접속, shutdown)

## 테스트
- `go test ./internal/proxy/ -v` → 2/2 PASS
- `make build` 성공

closes #7