### PR TITLE
feat: 쿼리 릴레이 구현

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -156,6 +156,20 @@ func ParseStartupParams(payload []byte) (major, minor uint16, params map[string]
 	return major, minor, params
 }
 
+// ExtractQueryText extracts the SQL string from a Query message payload.
+// Query payload is a null-terminated string.
+func ExtractQueryText(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	// Remove trailing null terminator
+	end := indexOf(payload, 0)
+	if end >= 0 {
+		return string(payload[:end])
+	}
+	return string(payload)
+}
+
 func indexOf(data []byte, b byte) int {
 	for i, v := range data {
 		if v == b {

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -80,3 +80,24 @@ func TestReadStartupMessage_SSLRequest(t *testing.T) {
 		t.Errorf("code = %d, want %d", code, SSLRequestCode)
 	}
 }
+
+func TestExtractQueryText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{"normal", []byte("SELECT 1\x00"), "SELECT 1"},
+		{"no null", []byte("SELECT 1"), "SELECT 1"},
+		{"empty", []byte{}, ""},
+		{"just null", []byte{0}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractQueryText(tt.payload)
+			if got != tt.want {
+				t.Errorf("ExtractQueryText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -145,38 +145,64 @@ func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
 	}
 }
 
-// relayQueries relays messages between client and backend bidirectionally.
-// TODO: T2-3에서 본격 구현 (현재는 단순 릴레이)
+// relayQueries reads client messages one at a time, forwards to backend,
+// and relays backend responses back to client. Message-level relay enables
+// future routing/caching hooks.
 func (s *Server) relayQueries(ctx context.Context, clientConn, backendConn net.Conn) {
-	done := make(chan struct{}, 2)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 
-	// Client → Backend
-	go func() {
-		defer func() { done <- struct{}{} }()
-		relay(clientConn, backendConn)
-	}()
+		// Read one message from client
+		msg, err := protocol.ReadMessage(clientConn)
+		if err != nil {
+			slog.Debug("client disconnected", "error", err)
+			return
+		}
 
-	// Backend → Client
-	go func() {
-		defer func() { done <- struct{}{} }()
-		relay(backendConn, clientConn)
-	}()
+		// Terminate message — close session
+		if msg.Type == protocol.MsgTerminate {
+			slog.Info("client terminated", "remote", clientConn.RemoteAddr())
+			return
+		}
 
-	select {
-	case <-done:
-	case <-ctx.Done():
+		// Extract query text for logging (Query messages: SQL + null terminator)
+		if msg.Type == protocol.MsgQuery {
+			query := protocol.ExtractQueryText(msg.Payload)
+			slog.Debug("query", "sql", query)
+		}
+
+		// Forward message to backend
+		if err := protocol.WriteMessage(backendConn, msg.Type, msg.Payload); err != nil {
+			slog.Error("forward to backend", "error", err)
+			return
+		}
+
+		// Relay backend responses until ReadyForQuery
+		if err := s.relayUntilReady(clientConn, backendConn); err != nil {
+			slog.Error("relay backend response", "error", err)
+			return
+		}
 	}
 }
 
-func relay(src, dst net.Conn) {
-	buf := make([]byte, 32*1024)
+// relayUntilReady forwards backend messages to client until ReadyForQuery ('Z').
+func (s *Server) relayUntilReady(clientConn, backendConn net.Conn) error {
 	for {
-		n, err := src.Read(buf)
+		msg, err := protocol.ReadMessage(backendConn)
 		if err != nil {
-			return
+			return fmt.Errorf("read backend response: %w", err)
 		}
-		if _, err := dst.Write(buf[:n]); err != nil {
-			return
+
+		if err := protocol.WriteMessage(clientConn, msg.Type, msg.Payload); err != nil {
+			return fmt.Errorf("forward to client: %w", err)
+		}
+
+		if msg.Type == protocol.MsgReadyForQuery {
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
## 변경 사항
- 바이트 릴레이 → 메시지 단위 릴레이로 변경
- `relayUntilReady()`: ReadyForQuery까지 백엔드 응답 전달
- `ExtractQueryText()`: Query 메시지에서 SQL 텍스트 추출
- Terminate 메시지 처리

## 테스트
- `go test ./... -v` → 전체 PASS (ExtractQueryText 서브테스트 4건 추가)

closes #11