### PR TITLE
feat: 커넥션 풀 기본 구조 구현

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,0 +1,235 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+)
+
+type Conn struct {
+	net.Conn
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+}
+
+func (c *Conn) expired(maxLifetime time.Duration) bool {
+	if maxLifetime <= 0 {
+		return false
+	}
+	return time.Since(c.CreatedAt) > maxLifetime
+}
+
+func (c *Conn) idle(idleTimeout time.Duration) bool {
+	if idleTimeout <= 0 {
+		return false
+	}
+	return time.Since(c.LastUsedAt) > idleTimeout
+}
+
+type Config struct {
+	Addr              string
+	MinConnections    int
+	MaxConnections    int
+	IdleTimeout       time.Duration
+	MaxLifetime       time.Duration
+	ConnectionTimeout time.Duration
+}
+
+type Pool struct {
+	cfg     Config
+	mu      sync.Mutex
+	idle    []*Conn
+	numOpen int
+	waitCh  chan struct{} // signals that a conn was released
+	closed  bool
+}
+
+func New(cfg Config) (*Pool, error) {
+	p := &Pool{
+		cfg:    cfg,
+		idle:   make([]*Conn, 0, cfg.MaxConnections),
+		waitCh: make(chan struct{}, cfg.MaxConnections),
+	}
+
+	// Pre-create min connections
+	for i := 0; i < cfg.MinConnections; i++ {
+		conn, err := p.newConn()
+		if err != nil {
+			p.Close()
+			return nil, fmt.Errorf("pre-create connection %d: %w", i, err)
+		}
+		p.idle = append(p.idle, conn)
+		p.numOpen++
+	}
+
+	return p, nil
+}
+
+func (p *Pool) Acquire(ctx context.Context) (*Conn, error) {
+	p.mu.Lock()
+
+	// Try to get a valid idle connection
+	for len(p.idle) > 0 {
+		conn := p.idle[len(p.idle)-1]
+		p.idle = p.idle[:len(p.idle)-1]
+
+		if conn.expired(p.cfg.MaxLifetime) || conn.idle(p.cfg.IdleTimeout) {
+			conn.Close()
+			p.numOpen--
+			continue
+		}
+
+		conn.LastUsedAt = time.Now()
+		p.mu.Unlock()
+		return conn, nil
+	}
+
+	// Can we create a new connection?
+	if p.numOpen < p.cfg.MaxConnections {
+		p.numOpen++
+		p.mu.Unlock()
+
+		conn, err := p.newConn()
+		if err != nil {
+			p.mu.Lock()
+			p.numOpen--
+			p.mu.Unlock()
+			return nil, err
+		}
+		return conn, nil
+	}
+
+	p.mu.Unlock()
+
+	// Wait for a released connection
+	timeout := p.cfg.ConnectionTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-p.waitCh:
+		return p.Acquire(ctx)
+	case <-timer.C:
+		return nil, fmt.Errorf("connection pool: acquire timeout after %v", timeout)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *Pool) Release(conn *Conn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		conn.Close()
+		p.numOpen--
+		return
+	}
+
+	conn.LastUsedAt = time.Now()
+	p.idle = append(p.idle, conn)
+
+	// Signal waiters
+	select {
+	case p.waitCh <- struct{}{}:
+	default:
+	}
+}
+
+func (p *Pool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	for _, conn := range p.idle {
+		conn.Close()
+	}
+	p.idle = nil
+	p.numOpen = 0
+}
+
+// Stats returns current pool statistics.
+func (p *Pool) Stats() (numOpen, numIdle int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.numOpen, len(p.idle)
+}
+
+func (p *Pool) newConn() (*Conn, error) {
+	netConn, err := net.DialTimeout("tcp", p.cfg.Addr, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", p.cfg.Addr, err)
+	}
+	now := time.Now()
+	return &Conn{
+		Conn:       netConn,
+		CreatedAt:  now,
+		LastUsedAt: now,
+	}, nil
+}
+
+// Ping checks if a connection is still alive.
+func Ping(conn *Conn) error {
+	conn.Conn.SetDeadline(time.Now().Add(time.Second))
+	defer conn.Conn.SetDeadline(time.Time{})
+
+	// Write a single null byte and see if connection errors
+	one := make([]byte, 0)
+	_, err := conn.Conn.Read(one)
+	if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
+		return nil // timeout is expected — connection is alive
+	}
+	return err
+}
+
+// StartHealthCheck runs a periodic health check goroutine.
+func (p *Pool) StartHealthCheck(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.healthCheck()
+			}
+		}
+	}()
+}
+
+func (p *Pool) healthCheck() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	alive := p.idle[:0]
+	for _, c := range p.idle {
+		if c.expired(p.cfg.MaxLifetime) || c.idle(p.cfg.IdleTimeout) {
+			c.Close()
+			p.numOpen--
+			slog.Debug("healthcheck: removed expired connection")
+		} else {
+			alive = append(alive, c)
+		}
+	}
+	p.idle = alive
+
+	// Replenish to min connections
+	for p.numOpen < p.cfg.MinConnections {
+		conn, err := p.newConn()
+		if err != nil {
+			slog.Error("healthcheck: replenish connection", "error", err)
+			break
+		}
+		p.idle = append(p.idle, conn)
+		p.numOpen++
+	}
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,0 +1,238 @@
+package pool
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// startEchoServer starts a TCP server that accepts connections and holds them open.
+func startEchoServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				buf := make([]byte, 1024)
+				for {
+					_, err := conn.Read(buf)
+					if err != nil {
+						conn.Close()
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+func TestPool_NewCreatesMinConnections(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:           addr,
+		MinConnections: 3,
+		MaxConnections: 10,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer p.Close()
+
+	numOpen, numIdle := p.Stats()
+	if numOpen != 3 {
+		t.Errorf("numOpen = %d, want 3", numOpen)
+	}
+	if numIdle != 3 {
+		t.Errorf("numIdle = %d, want 3", numIdle)
+	}
+}
+
+func TestPool_AcquireRelease(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:           addr,
+		MinConnections: 1,
+		MaxConnections: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	ctx := context.Background()
+
+	conn1, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("Acquire() error: %v", err)
+	}
+
+	numOpen, numIdle := p.Stats()
+	if numIdle != 0 {
+		t.Errorf("after acquire: numIdle = %d, want 0", numIdle)
+	}
+
+	p.Release(conn1)
+
+	numOpen, numIdle = p.Stats()
+	if numIdle != 1 {
+		t.Errorf("after release: numIdle = %d, want 1", numIdle)
+	}
+
+	// Re-acquire should reuse the connection
+	conn2, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("Acquire() error: %v", err)
+	}
+
+	if conn2 != conn1 {
+		t.Error("expected connection reuse")
+	}
+	_ = numOpen
+
+	p.Release(conn2)
+}
+
+func TestPool_AcquireTimeout(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:              addr,
+		MinConnections:    0,
+		MaxConnections:    1,
+		ConnectionTimeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	ctx := context.Background()
+
+	// Acquire the only connection
+	conn, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second acquire should timeout
+	_, err = p.Acquire(ctx)
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+
+	p.Release(conn)
+}
+
+func TestPool_IdleTimeout(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:           addr,
+		MinConnections: 0,
+		MaxConnections: 5,
+		IdleTimeout:    50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	ctx := context.Background()
+
+	conn, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Release(conn)
+
+	// Wait for idle timeout
+	time.Sleep(100 * time.Millisecond)
+
+	// Should get a new connection (old one expired)
+	conn2, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Release(conn2)
+
+	if conn2 == conn {
+		t.Error("expected new connection after idle timeout, got same connection")
+	}
+}
+
+func TestPool_MaxLifetime(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:           addr,
+		MinConnections: 0,
+		MaxConnections: 5,
+		MaxLifetime:    50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	ctx := context.Background()
+
+	conn, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Release(conn)
+
+	time.Sleep(100 * time.Millisecond)
+
+	conn2, err := p.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Release(conn2)
+
+	if conn2 == conn {
+		t.Error("expected new connection after max lifetime, got same connection")
+	}
+}
+
+func TestPool_HealthCheck(t *testing.T) {
+	addr := startEchoServer(t)
+
+	p, err := New(Config{
+		Addr:           addr,
+		MinConnections: 2,
+		MaxConnections: 5,
+		IdleTimeout:    50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.StartHealthCheck(ctx, 30*time.Millisecond)
+
+	// Wait for idle connections to expire and be replenished
+	time.Sleep(150 * time.Millisecond)
+
+	numOpen, _ := p.Stats()
+	if numOpen < 2 {
+		t.Errorf("after healthcheck: numOpen = %d, want >= 2 (min_connections)", numOpen)
+	}
+}


### PR DESCRIPTION
## 변경 사항
- `internal/pool/pool.go`: Pool, Conn, Acquire, Release, Close, Stats, HealthCheck
- 테스트 6건 (min 생성, 재사용, 타임아웃, idle만료, lifetime만료, 헬스체크)

## 테스트
- `go test ./internal/pool/ -v` → 6/6 PASS

closes #13