### PR TITLE
feat: 쿼리 R/W 분류 파서 및 라우팅 구현

### DIFF
--- a/internal/router/balancer.go
+++ b/internal/router/balancer.go
@@ -1,0 +1,100 @@
+package router
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Backend struct {
+	Addr    string
+	healthy atomic.Bool
+}
+
+type RoundRobin struct {
+	mu       sync.RWMutex
+	backends []*Backend
+	index    atomic.Uint64
+}
+
+func NewRoundRobin(addrs []string) *RoundRobin {
+	backends := make([]*Backend, len(addrs))
+	for i, addr := range addrs {
+		b := &Backend{Addr: addr}
+		b.healthy.Store(true)
+		backends[i] = b
+	}
+	return &RoundRobin{backends: backends}
+}
+
+// Next returns the address of the next healthy backend.
+// Returns empty string if no healthy backend is available.
+func (r *RoundRobin) Next() string {
+	n := len(r.backends)
+	if n == 0 {
+		return ""
+	}
+
+	for i := 0; i < n; i++ {
+		idx := int(r.index.Add(1)-1) % n
+		if r.backends[idx].healthy.Load() {
+			return r.backends[idx].Addr
+		}
+	}
+	return ""
+}
+
+// MarkUnhealthy marks a backend as unhealthy.
+func (r *RoundRobin) MarkUnhealthy(addr string) {
+	for _, b := range r.backends {
+		if b.Addr == addr {
+			b.healthy.Store(false)
+			slog.Warn("backend marked unhealthy", "addr", addr)
+			return
+		}
+	}
+}
+
+// StartHealthCheck periodically checks unhealthy backends and restores them.
+func (r *RoundRobin) StartHealthCheck(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.checkBackends()
+			}
+		}
+	}()
+}
+
+func (r *RoundRobin) checkBackends() {
+	for _, b := range r.backends {
+		if !b.healthy.Load() {
+			conn, err := net.DialTimeout("tcp", b.Addr, 2*time.Second)
+			if err == nil {
+				conn.Close()
+				b.healthy.Store(true)
+				slog.Info("backend recovered", "addr", b.Addr)
+			}
+		}
+	}
+}
+
+// HealthyCount returns the number of healthy backends.
+func (r *RoundRobin) HealthyCount() int {
+	count := 0
+	for _, b := range r.backends {
+		if b.healthy.Load() {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/router/balancer_test.go
+++ b/internal/router/balancer_test.go
@@ -1,0 +1,98 @@
+package router
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestRoundRobin_Distribution(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+
+	counts := map[string]int{}
+	for i := 0; i < 9; i++ {
+		addr := rb.Next()
+		counts[addr]++
+	}
+
+	for _, addr := range []string{"a:1", "b:2", "c:3"} {
+		if counts[addr] != 3 {
+			t.Errorf("count[%s] = %d, want 3", addr, counts[addr])
+		}
+	}
+}
+
+func TestRoundRobin_SkipUnhealthy(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+
+	rb.MarkUnhealthy("b:2")
+
+	for i := 0; i < 6; i++ {
+		addr := rb.Next()
+		if addr == "b:2" {
+			t.Error("unhealthy backend b:2 should be skipped")
+		}
+	}
+}
+
+func TestRoundRobin_AllUnhealthy(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2"})
+
+	rb.MarkUnhealthy("a:1")
+	rb.MarkUnhealthy("b:2")
+
+	if addr := rb.Next(); addr != "" {
+		t.Errorf("Next() = %q, want empty when all unhealthy", addr)
+	}
+}
+
+func TestRoundRobin_HealthyCount(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+
+	if got := rb.HealthyCount(); got != 3 {
+		t.Errorf("HealthyCount() = %d, want 3", got)
+	}
+
+	rb.MarkUnhealthy("b:2")
+
+	if got := rb.HealthyCount(); got != 2 {
+		t.Errorf("HealthyCount() = %d, want 2", got)
+	}
+}
+
+func TestRoundRobin_Recovery(t *testing.T) {
+	// Start a real TCP server to simulate recovery
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	addr := ln.Addr().String()
+	rb := NewRoundRobin([]string{addr})
+	rb.MarkUnhealthy(addr)
+
+	if rb.HealthyCount() != 0 {
+		t.Error("expected 0 healthy after marking unhealthy")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rb.StartHealthCheck(ctx, 50*time.Millisecond)
+
+	time.Sleep(150 * time.Millisecond)
+
+	if rb.HealthyCount() != 1 {
+		t.Error("expected backend to recover after health check")
+	}
+}

--- a/internal/router/parser.go
+++ b/internal/router/parser.go
@@ -1,0 +1,113 @@
+package router
+
+import (
+	"regexp"
+	"strings"
+)
+
+type QueryType int
+
+const (
+	QueryRead  QueryType = iota
+	QueryWrite
+)
+
+var writeKeywords = map[string]bool{
+	"INSERT":   true,
+	"UPDATE":   true,
+	"DELETE":   true,
+	"CREATE":   true,
+	"ALTER":    true,
+	"DROP":     true,
+	"TRUNCATE": true,
+	"GRANT":    true,
+	"REVOKE":   true,
+}
+
+var hintRegex = regexp.MustCompile(`/\*\s*route:(writer|reader)\s*\*/`)
+
+// Classify determines whether a query is a read or write operation.
+func Classify(query string) QueryType {
+	// 1. Check for routing hint
+	if hint := extractHint(query); hint != "" {
+		if hint == "writer" {
+			return QueryWrite
+		}
+		return QueryRead
+	}
+
+	// 2. Classify by first keyword
+	keyword := firstKeyword(query)
+	if writeKeywords[keyword] {
+		return QueryWrite
+	}
+	return QueryRead
+}
+
+func extractHint(query string) string {
+	matches := hintRegex.FindStringSubmatch(query)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+func firstKeyword(query string) string {
+	q := stripComments(query)
+	q = strings.TrimSpace(q)
+	fields := strings.Fields(q)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToUpper(fields[0])
+}
+
+func stripComments(query string) string {
+	// Remove /* ... */ comments
+	re := regexp.MustCompile(`/\*.*?\*/`)
+	q := re.ReplaceAllString(query, "")
+
+	// Remove -- line comments
+	re2 := regexp.MustCompile(`--[^\n]*`)
+	q = re2.ReplaceAllString(q, "")
+
+	return q
+}
+
+// ExtractTables extracts table names from write queries.
+func ExtractTables(query string) []string {
+	q := strings.TrimSpace(query)
+	upper := strings.ToUpper(q)
+
+	var tables []string
+
+	switch {
+	case strings.HasPrefix(upper, "INSERT INTO"):
+		tables = append(tables, extractAfter(q, upper, "INSERT INTO"))
+	case strings.HasPrefix(upper, "UPDATE"):
+		tables = append(tables, extractAfter(q, upper, "UPDATE"))
+	case strings.HasPrefix(upper, "DELETE FROM"):
+		tables = append(tables, extractAfter(q, upper, "DELETE FROM"))
+	case strings.HasPrefix(upper, "TRUNCATE"):
+		tables = append(tables, extractAfter(q, upper, "TRUNCATE"))
+	}
+
+	return tables
+}
+
+func extractAfter(query, upper, keyword string) string {
+	rest := strings.TrimSpace(query[len(keyword):])
+	// Handle optional keywords like "TABLE"
+	upperRest := strings.ToUpper(rest)
+	if strings.HasPrefix(upperRest, "TABLE ") {
+		rest = strings.TrimSpace(rest[6:])
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	// Remove schema prefix and clean up
+	name := strings.TrimRight(fields[0], "(;,")
+	parts := strings.Split(name, ".")
+	return strings.ToLower(parts[len(parts)-1])
+}

--- a/internal/router/parser_test.go
+++ b/internal/router/parser_test.go
@@ -1,0 +1,67 @@
+package router
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		query string
+		want  QueryType
+	}{
+		{"SELECT * FROM users", QueryRead},
+		{"select * from users", QueryRead},
+		{"  SELECT 1", QueryRead},
+		{"SHOW tables", QueryRead},
+		{"EXPLAIN SELECT 1", QueryRead},
+		{"INSERT INTO users VALUES (1)", QueryWrite},
+		{"insert into users values (1)", QueryWrite},
+		{"UPDATE users SET name = 'a'", QueryWrite},
+		{"DELETE FROM users WHERE id = 1", QueryWrite},
+		{"CREATE TABLE foo (id int)", QueryWrite},
+		{"ALTER TABLE foo ADD col int", QueryWrite},
+		{"DROP TABLE foo", QueryWrite},
+		{"TRUNCATE users", QueryWrite},
+		// Hint comments
+		{"/* route:writer */ SELECT * FROM users", QueryWrite},
+		{"/* route:reader */ INSERT INTO users VALUES (1)", QueryRead},
+		{"/*route:writer*/ SELECT 1", QueryWrite},
+		{"/* route:reader */ SELECT 1", QueryRead},
+		// Regular comments should be stripped
+		{"-- comment\nSELECT 1", QueryRead},
+		{"/* normal comment */ SELECT 1", QueryRead},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := Classify(tt.query)
+			if got != tt.want {
+				t.Errorf("Classify(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTables(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"INSERT INTO users VALUES (1)", "users"},
+		{"insert into users values (1)", "users"},
+		{"UPDATE orders SET status = 'done'", "orders"},
+		{"DELETE FROM products WHERE id = 1", "products"},
+		{"TRUNCATE TABLE logs", "logs"},
+		{"INSERT INTO public.users VALUES (1)", "users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			tables := ExtractTables(tt.query)
+			if len(tables) == 0 {
+				t.Fatalf("ExtractTables(%q) returned empty", tt.query)
+			}
+			if tables[0] != tt.want {
+				t.Errorf("ExtractTables(%q) = %q, want %q", tt.query, tables[0], tt.want)
+			}
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,73 @@
+package router
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type Route int
+
+const (
+	RouteWriter Route = iota
+	RouteReader
+)
+
+type Session struct {
+	mu                  sync.Mutex
+	inTransaction       bool
+	lastWriteTime       time.Time
+	readAfterWriteDelay time.Duration
+}
+
+func NewSession(readAfterWriteDelay time.Duration) *Session {
+	return &Session{
+		readAfterWriteDelay: readAfterWriteDelay,
+	}
+}
+
+// Route determines where to send the query based on session state and query type.
+func (s *Session) Route(query string) Route {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	upper := strings.ToUpper(strings.TrimSpace(query))
+
+	// Track transaction state
+	if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START TRANSACTION") {
+		s.inTransaction = true
+		return RouteWriter
+	}
+	if strings.HasPrefix(upper, "COMMIT") || strings.HasPrefix(upper, "ROLLBACK") {
+		s.inTransaction = false
+		return RouteWriter
+	}
+
+	// All queries in a transaction go to writer
+	if s.inTransaction {
+		return RouteWriter
+	}
+
+	qtype := Classify(query)
+
+	// Write query
+	if qtype == QueryWrite {
+		s.lastWriteTime = time.Now()
+		return RouteWriter
+	}
+
+	// Read-after-write: send to writer within delay window
+	if s.readAfterWriteDelay > 0 && !s.lastWriteTime.IsZero() &&
+		time.Since(s.lastWriteTime) < s.readAfterWriteDelay {
+		return RouteWriter
+	}
+
+	return RouteReader
+}
+
+// InTransaction returns whether the session is currently in a transaction.
+func (s *Session) InTransaction() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inTransaction
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,78 @@
+package router
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSession_BasicRouting(t *testing.T) {
+	s := NewSession(0)
+
+	if got := s.Route("SELECT * FROM users"); got != RouteReader {
+		t.Errorf("SELECT → %d, want RouteReader", got)
+	}
+	if got := s.Route("INSERT INTO users VALUES (1)"); got != RouteWriter {
+		t.Errorf("INSERT → %d, want RouteWriter", got)
+	}
+}
+
+func TestSession_Transaction(t *testing.T) {
+	s := NewSession(0)
+
+	// BEGIN → all queries go to writer
+	if got := s.Route("BEGIN"); got != RouteWriter {
+		t.Errorf("BEGIN → %d, want RouteWriter", got)
+	}
+	if got := s.Route("SELECT * FROM users"); got != RouteWriter {
+		t.Errorf("SELECT in tx → %d, want RouteWriter", got)
+	}
+	if got := s.Route("INSERT INTO users VALUES (1)"); got != RouteWriter {
+		t.Errorf("INSERT in tx → %d, want RouteWriter", got)
+	}
+
+	// COMMIT → back to normal routing
+	if got := s.Route("COMMIT"); got != RouteWriter {
+		t.Errorf("COMMIT → %d, want RouteWriter", got)
+	}
+	if got := s.Route("SELECT * FROM users"); got != RouteReader {
+		t.Errorf("SELECT after commit → %d, want RouteReader", got)
+	}
+}
+
+func TestSession_ReadAfterWriteDelay(t *testing.T) {
+	s := NewSession(100 * time.Millisecond)
+
+	// Write
+	s.Route("INSERT INTO users VALUES (1)")
+
+	// Read immediately after write → writer
+	if got := s.Route("SELECT * FROM users"); got != RouteWriter {
+		t.Errorf("SELECT after write → %d, want RouteWriter", got)
+	}
+
+	// Wait for delay to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Read after delay → reader
+	if got := s.Route("SELECT * FROM users"); got != RouteReader {
+		t.Errorf("SELECT after delay → %d, want RouteReader", got)
+	}
+}
+
+func TestSession_Rollback(t *testing.T) {
+	s := NewSession(0)
+
+	s.Route("BEGIN")
+	if !s.InTransaction() {
+		t.Error("expected InTransaction=true after BEGIN")
+	}
+
+	s.Route("ROLLBACK")
+	if s.InTransaction() {
+		t.Error("expected InTransaction=false after ROLLBACK")
+	}
+
+	if got := s.Route("SELECT 1"); got != RouteReader {
+		t.Errorf("SELECT after rollback → %d, want RouteReader", got)
+	}
+}


### PR DESCRIPTION
## 변경 사항
- `internal/router/parser.go`: Classify(), ExtractTables(), 힌트 주석 파싱
- `internal/router/router.go`: Session, Route(), 트랜잭션 추적, read_after_write_delay
- `internal/router/balancer.go`: RoundRobin, 장애 감지, 자동 복구 헬스체크

## 테스트
- `go test ./internal/router/ -v` → 34건 전체 PASS

closes #15