### PR TITLE
feat: LRU 쿼리 캐시 및 테이블별 무효화 구현

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,175 @@
+package cache
+
+import (
+	"container/list"
+	"hash/fnv"
+	"sync"
+	"time"
+)
+
+type entry struct {
+	key       uint64
+	result    []byte
+	tables    []string
+	expiresAt time.Time
+}
+
+type Cache struct {
+	mu         sync.RWMutex
+	items      map[uint64]*list.Element
+	evictList  *list.List
+	maxEntries int
+	ttl        time.Duration
+	maxSize    int // max result size in bytes
+
+	// Table → cache keys reverse index for invalidation
+	tableIndex map[string]map[uint64]struct{}
+}
+
+type Config struct {
+	MaxEntries int
+	TTL        time.Duration
+	MaxSize    int // max single result size in bytes
+}
+
+func New(cfg Config) *Cache {
+	return &Cache{
+		items:      make(map[uint64]*list.Element),
+		evictList:  list.New(),
+		maxEntries: cfg.MaxEntries,
+		ttl:        cfg.TTL,
+		maxSize:    cfg.MaxSize,
+		tableIndex: make(map[string]map[uint64]struct{}),
+	}
+}
+
+// CacheKey generates a hash key from query text and parameters.
+func CacheKey(query string, params ...any) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(query))
+	for _, p := range params {
+		if s, ok := p.(string); ok {
+			h.Write([]byte(s))
+		}
+	}
+	return h.Sum64()
+}
+
+// Get retrieves a cached result. Returns nil if not found or expired.
+func (c *Cache) Get(key uint64) []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.items[key]
+	if !ok {
+		return nil
+	}
+
+	e := elem.Value.(*entry)
+
+	// Check TTL
+	if time.Now().After(e.expiresAt) {
+		c.removeElement(elem)
+		return nil
+	}
+
+	// Move to front (most recently used)
+	c.evictList.MoveToFront(elem)
+	return e.result
+}
+
+// Set stores a query result in the cache.
+func (c *Cache) Set(key uint64, result []byte, tables []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Skip if result too large
+	if c.maxSize > 0 && len(result) > c.maxSize {
+		return
+	}
+
+	// Update existing entry
+	if elem, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(elem)
+		e := elem.Value.(*entry)
+		e.result = result
+		e.tables = tables
+		e.expiresAt = time.Now().Add(c.ttl)
+		c.updateTableIndex(key, tables)
+		return
+	}
+
+	// Evict if at capacity
+	if c.maxEntries > 0 && c.evictList.Len() >= c.maxEntries {
+		c.evictOldest()
+	}
+
+	// Add new entry
+	e := &entry{
+		key:       key,
+		result:    result,
+		tables:    tables,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	elem := c.evictList.PushFront(e)
+	c.items[key] = elem
+	c.updateTableIndex(key, tables)
+}
+
+// InvalidateTable removes all cache entries that reference the given table.
+func (c *Cache) InvalidateTable(table string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	keys, ok := c.tableIndex[table]
+	if !ok {
+		return
+	}
+
+	for key := range keys {
+		if elem, ok := c.items[key]; ok {
+			c.removeElement(elem)
+		}
+	}
+
+	delete(c.tableIndex, table)
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.evictList.Len()
+}
+
+func (c *Cache) removeElement(elem *list.Element) {
+	e := elem.Value.(*entry)
+	c.evictList.Remove(elem)
+	delete(c.items, e.key)
+
+	// Clean up table index
+	for _, table := range e.tables {
+		if keys, ok := c.tableIndex[table]; ok {
+			delete(keys, e.key)
+			if len(keys) == 0 {
+				delete(c.tableIndex, table)
+			}
+		}
+	}
+}
+
+func (c *Cache) evictOldest() {
+	elem := c.evictList.Back()
+	if elem != nil {
+		c.removeElement(elem)
+	}
+}
+
+func (c *Cache) updateTableIndex(key uint64, tables []string) {
+	for _, table := range tables {
+		if _, ok := c.tableIndex[table]; !ok {
+			c.tableIndex[table] = make(map[uint64]struct{})
+		}
+		c.tableIndex[table][key] = struct{}{}
+	}
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,149 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCache_GetSet(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 1024})
+
+	key := CacheKey("SELECT * FROM users")
+	c.Set(key, []byte("result"), []string{"users"})
+
+	got := c.Get(key)
+	if string(got) != "result" {
+		t.Errorf("Get() = %q, want %q", got, "result")
+	}
+}
+
+func TestCache_Miss(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 1024})
+
+	got := c.Get(12345)
+	if got != nil {
+		t.Errorf("Get(missing) = %q, want nil", got)
+	}
+}
+
+func TestCache_TTLExpiry(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: 50 * time.Millisecond, MaxSize: 1024})
+
+	key := CacheKey("SELECT 1")
+	c.Set(key, []byte("result"), nil)
+
+	// Should hit before TTL
+	if got := c.Get(key); got == nil {
+		t.Error("Get() before TTL = nil, want result")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Should miss after TTL
+	if got := c.Get(key); got != nil {
+		t.Errorf("Get() after TTL = %q, want nil", got)
+	}
+}
+
+func TestCache_MaxEntries_LRU(t *testing.T) {
+	c := New(Config{MaxEntries: 3, TTL: time.Minute, MaxSize: 1024})
+
+	k1 := CacheKey("SELECT 1")
+	k2 := CacheKey("SELECT 2")
+	k3 := CacheKey("SELECT 3")
+	k4 := CacheKey("SELECT 4")
+
+	c.Set(k1, []byte("r1"), nil)
+	c.Set(k2, []byte("r2"), nil)
+	c.Set(k3, []byte("r3"), nil)
+
+	// Access k1 to make it recently used
+	c.Get(k1)
+
+	// Add k4 — should evict k2 (least recently used)
+	c.Set(k4, []byte("r4"), nil)
+
+	if c.Len() != 3 {
+		t.Errorf("Len() = %d, want 3", c.Len())
+	}
+
+	// k1 should still exist (recently accessed)
+	if got := c.Get(k1); got == nil {
+		t.Error("k1 should still exist after eviction")
+	}
+
+	// k2 should be evicted
+	if got := c.Get(k2); got != nil {
+		t.Error("k2 should have been evicted")
+	}
+
+	// k3, k4 should exist
+	if got := c.Get(k3); got == nil {
+		t.Error("k3 should still exist")
+	}
+	if got := c.Get(k4); got == nil {
+		t.Error("k4 should still exist")
+	}
+}
+
+func TestCache_MaxSize_Skip(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 10})
+
+	key := CacheKey("SELECT * FROM big_table")
+	bigResult := make([]byte, 100)
+	c.Set(key, bigResult, nil)
+
+	if got := c.Get(key); got != nil {
+		t.Error("large result should not be cached")
+	}
+	if c.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", c.Len())
+	}
+}
+
+func TestCache_InvalidateTable(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 1024})
+
+	k1 := CacheKey("SELECT * FROM users")
+	k2 := CacheKey("SELECT * FROM users WHERE id = 1")
+	k3 := CacheKey("SELECT * FROM orders")
+
+	c.Set(k1, []byte("r1"), []string{"users"})
+	c.Set(k2, []byte("r2"), []string{"users"})
+	c.Set(k3, []byte("r3"), []string{"orders"})
+
+	// Invalidate users table
+	c.InvalidateTable("users")
+
+	if got := c.Get(k1); got != nil {
+		t.Error("k1 (users) should be invalidated")
+	}
+	if got := c.Get(k2); got != nil {
+		t.Error("k2 (users) should be invalidated")
+	}
+	if got := c.Get(k3); got == nil {
+		t.Error("k3 (orders) should still exist")
+	}
+
+	if c.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", c.Len())
+	}
+}
+
+func TestCacheKey_SameQuerySameKey(t *testing.T) {
+	k1 := CacheKey("SELECT * FROM users")
+	k2 := CacheKey("SELECT * FROM users")
+
+	if k1 != k2 {
+		t.Errorf("same query produced different keys: %d vs %d", k1, k2)
+	}
+}
+
+func TestCacheKey_DifferentQueryDifferentKey(t *testing.T) {
+	k1 := CacheKey("SELECT * FROM users")
+	k2 := CacheKey("SELECT * FROM orders")
+
+	if k1 == k2 {
+		t.Error("different queries produced same key")
+	}
+}


### PR DESCRIPTION
## 변경 사항
- `internal/cache/cache.go`: LRU 캐시, TTL, max_entries, max_size, 테이블별 무효화
- 테스트 8건 (get/set, miss, TTL, LRU eviction, max_size skip, table invalidation, key consistency)

## 테스트
- `go test ./... -count=1` → 전체 PASS

closes #17