### PR TITLE
feat: Pool/Router/Cache 프록시 통합 (#21)

### DIFF
--- a/cmd/db-proxy/main.go
+++ b/cmd/db-proxy/main.go
@@ -21,8 +21,17 @@ func main() {
 
 func run() error {
 	cfgPath := "config.yaml"
-	if len(os.Args) > 1 {
-		cfgPath = os.Args[1]
+	debug := false
+	for _, arg := range os.Args[1:] {
+		if arg == "-debug" {
+			debug = true
+		} else {
+			cfgPath = arg
+		}
+	}
+
+	if debug {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	}
 
 	cfg, err := config.Load(cfgPath)

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -26,3 +26,8 @@ cache:
   cache_ttl: 5s
   max_cache_entries: 1000
   max_result_size: "512KB"
+
+backend:
+  user: "postgres"
+  password: "postgres"
+  database: "testdb"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,14 @@ services:
       - "15432:5432"
     volumes:
       - ./docker/primary/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./docker/primary/pg_hba.conf:/var/lib/postgresql/pg_hba.conf
     command: >
       postgres
       -c wal_level=replica
-      -c max_wal_senders=3
-      -c max_replication_slots=3
+      -c max_wal_senders=10
+      -c max_replication_slots=10
       -c hot_standby=on
+      -c hba_file=/var/lib/postgresql/pg_hba.conf
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s

--- a/docker/primary/init.sql
+++ b/docker/primary/init.sql
@@ -1,12 +1,9 @@
 -- Create replication user
 CREATE USER replicator WITH REPLICATION ENCRYPTED PASSWORD 'replicator';
 
--- Grant permissions
+-- Create replication slots
 SELECT pg_create_physical_replication_slot('replica1_slot');
 SELECT pg_create_physical_replication_slot('replica2_slot');
-
--- Allow replication connections
--- (pg_hba.conf is handled by the Docker image automatically for trust auth)
 
 -- Create test table
 CREATE TABLE users (

--- a/docker/primary/pg_hba.conf
+++ b/docker/primary/pg_hba.conf
@@ -1,0 +1,4 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     trust
+host    all             all             0.0.0.0/0               md5
+host    replication     replicator      0.0.0.0/0               md5

--- a/docker/replica/setup.sh
+++ b/docker/replica/setup.sh
@@ -2,17 +2,18 @@
 set -e
 
 # Wait for primary to be ready
-until pg_isready -h primary -p 5432 -U postgres; do
+until PGPASSWORD=replicator pg_isready -h primary -p 5432 -U postgres; do
   echo "Waiting for primary..."
   sleep 1
 done
 
 # Clean data directory and create base backup
 rm -rf /var/lib/postgresql/data/*
-pg_basebackup -h primary -p 5432 -U replicator -D /var/lib/postgresql/data -Fp -Xs -P -R
+PGPASSWORD=replicator pg_basebackup -h primary -p 5432 -U replicator -D /var/lib/postgresql/data -Fp -Xs -P -R
 
 # Ensure proper permissions
+chown -R postgres:postgres /var/lib/postgresql/data
 chmod 700 /var/lib/postgresql/data
 
-# Start postgres in replica mode
-exec postgres -c hot_standby=on
+# Start postgres as postgres user
+exec su-exec postgres postgres -c hot_standby=on

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/jyukki97/db-proxy
 go 1.25.1
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/lib/pq v1.11.2 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
+github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,13 @@ type Config struct {
 	Pool    PoolConfig    `yaml:"pool"`
 	Routing RoutingConfig `yaml:"routing"`
 	Cache   CacheConfig   `yaml:"cache"`
+	Backend BackendConfig `yaml:"backend"`
+}
+
+type BackendConfig struct {
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+	Database string `yaml:"database"`
 }
 
 type ProxyConfig struct {
@@ -95,6 +102,12 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Cache.MaxResultSize == "" {
 		c.Cache.MaxResultSize = "1MB"
+	}
+	if c.Backend.User == "" {
+		c.Backend.User = "postgres"
+	}
+	if c.Backend.Database == "" {
+		c.Backend.Database = "postgres"
 	}
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -29,7 +29,11 @@ func (c *Conn) idle(idleTimeout time.Duration) bool {
 	return time.Since(c.LastUsedAt) > idleTimeout
 }
 
+// DialFunc creates a new connection. If nil, raw TCP dial is used.
+type DialFunc func() (net.Conn, error)
+
 type Config struct {
+	DialFunc          DialFunc
 	Addr              string
 	MinConnections    int
 	MaxConnections    int
@@ -162,8 +166,28 @@ func (p *Pool) Stats() (numOpen, numIdle int) {
 	return p.numOpen, len(p.idle)
 }
 
+// Discard closes a broken connection and decrements the open count.
+// Use this instead of Release when the connection is no longer usable.
+func (p *Pool) Discard(conn *Conn) {
+	conn.Close()
+	p.mu.Lock()
+	p.numOpen--
+	p.mu.Unlock()
+
+	select {
+	case p.waitCh <- struct{}{}:
+	default:
+	}
+}
+
 func (p *Pool) newConn() (*Conn, error) {
-	netConn, err := net.DialTimeout("tcp", p.cfg.Addr, 5*time.Second)
+	var netConn net.Conn
+	var err error
+	if p.cfg.DialFunc != nil {
+		netConn, err = p.cfg.DialFunc()
+	} else {
+		netConn, err = net.DialTimeout("tcp", p.cfg.Addr, 5*time.Second)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", p.cfg.Addr, err)
 	}

--- a/internal/proxy/pgconn.go
+++ b/internal/proxy/pgconn.go
@@ -1,0 +1,259 @@
+package proxy
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/jyukki97/db-proxy/internal/protocol"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// pgConnect establishes an authenticated PostgreSQL connection.
+// Supports MD5 and SCRAM-SHA-256 authentication.
+func pgConnect(addr, user, password, database string) (net.Conn, error) {
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", addr, err)
+	}
+
+	// Build and send startup message
+	startup := protocol.BuildStartupMessage(map[string]string{
+		"user":     user,
+		"database": database,
+	})
+	if err := protocol.WriteRaw(conn, startup); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("send startup: %w", err)
+	}
+
+	// Handle authentication flow
+	for {
+		msg, err := protocol.ReadMessage(conn)
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("read auth: %w", err)
+		}
+
+		switch msg.Type {
+		case protocol.MsgAuthentication:
+			if len(msg.Payload) < 4 {
+				conn.Close()
+				return nil, fmt.Errorf("invalid auth message")
+			}
+			authType := binary.BigEndian.Uint32(msg.Payload[0:4])
+			switch authType {
+			case 0: // AuthenticationOk
+			case 3: // CleartextPassword
+				pwMsg := append([]byte(password), 0)
+				if err := protocol.WriteMessage(conn, 'p', pwMsg); err != nil {
+					conn.Close()
+					return nil, fmt.Errorf("send cleartext password: %w", err)
+				}
+			case 5: // MD5Password
+				if len(msg.Payload) < 8 {
+					conn.Close()
+					return nil, fmt.Errorf("md5 auth: missing salt")
+				}
+				salt := msg.Payload[4:8]
+				hash := pgMD5Password(user, password, salt)
+				pwMsg := append([]byte(hash), 0)
+				if err := protocol.WriteMessage(conn, 'p', pwMsg); err != nil {
+					conn.Close()
+					return nil, fmt.Errorf("send md5 password: %w", err)
+				}
+			case 10: // AuthenticationSASL
+				if err := handleSCRAM(conn, msg.Payload[4:], user, password); err != nil {
+					conn.Close()
+					return nil, fmt.Errorf("scram auth: %w", err)
+				}
+			default:
+				conn.Close()
+				return nil, fmt.Errorf("unsupported auth type: %d", authType)
+			}
+
+		case protocol.MsgErrorResponse:
+			conn.Close()
+			return nil, fmt.Errorf("backend auth error")
+
+		case protocol.MsgReadyForQuery:
+			return conn, nil
+
+		default:
+			// Skip ParameterStatus, BackendKeyData, etc.
+		}
+	}
+}
+
+// handleSCRAM performs SCRAM-SHA-256 authentication.
+func handleSCRAM(conn net.Conn, mechanisms []byte, user, password string) error {
+	// Verify SCRAM-SHA-256 is offered
+	mechList := string(mechanisms)
+	if !strings.Contains(mechList, "SCRAM-SHA-256") {
+		return fmt.Errorf("SCRAM-SHA-256 not offered: %s", mechList)
+	}
+
+	// Step 1: Send SASLInitialResponse
+	clientNonce := generateNonce()
+	clientFirstBare := fmt.Sprintf("n=%s,r=%s", user, clientNonce)
+	clientFirstMsg := "n,," + clientFirstBare
+
+	// SASLInitialResponse: mechanism name + \0 + int32 length + data
+	var saslResp []byte
+	saslResp = append(saslResp, []byte("SCRAM-SHA-256")...)
+	saslResp = append(saslResp, 0)
+	respData := []byte(clientFirstMsg)
+	saslResp = binary.BigEndian.AppendUint32(saslResp, uint32(len(respData)))
+	saslResp = append(saslResp, respData...)
+
+	if err := protocol.WriteMessage(conn, 'p', saslResp); err != nil {
+		return fmt.Errorf("send SASL initial: %w", err)
+	}
+
+	// Step 2: Read AuthenticationSASLContinue (type 11)
+	msg, err := protocol.ReadMessage(conn)
+	if err != nil {
+		return fmt.Errorf("read SASL continue: %w", err)
+	}
+	if msg.Type == protocol.MsgErrorResponse {
+		return fmt.Errorf("SASL auth error from server")
+	}
+	if msg.Type != protocol.MsgAuthentication || len(msg.Payload) < 4 {
+		return fmt.Errorf("unexpected message during SASL: type=%c", msg.Type)
+	}
+	if binary.BigEndian.Uint32(msg.Payload[0:4]) != 11 {
+		return fmt.Errorf("expected SASLContinue(11), got %d", binary.BigEndian.Uint32(msg.Payload[0:4]))
+	}
+
+	serverFirstMsg := string(msg.Payload[4:])
+
+	// Parse server-first-message: r=<nonce>,s=<salt>,i=<iterations>
+	serverNonce, salt, iterations, err := parseServerFirst(serverFirstMsg)
+	if err != nil {
+		return fmt.Errorf("parse server-first: %w", err)
+	}
+
+	// Verify server nonce starts with client nonce
+	if !strings.HasPrefix(serverNonce, clientNonce) {
+		return fmt.Errorf("server nonce doesn't match client nonce")
+	}
+
+	// Step 3: Compute client proof and send SASLResponse
+	saltedPassword := pbkdf2.Key([]byte(password), salt, iterations, 32, sha256.New)
+
+	clientKey := hmacSHA256(saltedPassword, []byte("Client Key"))
+	storedKey := sha256Sum(clientKey)
+
+	clientFinalWithoutProof := fmt.Sprintf("c=biws,r=%s", serverNonce)
+	authMessage := clientFirstBare + "," + serverFirstMsg + "," + clientFinalWithoutProof
+
+	clientSignature := hmacSHA256(storedKey, []byte(authMessage))
+	clientProof := xorBytes(clientKey, clientSignature)
+
+	clientFinalMsg := clientFinalWithoutProof + ",p=" + base64.StdEncoding.EncodeToString(clientProof)
+
+	if err := protocol.WriteMessage(conn, 'p', []byte(clientFinalMsg)); err != nil {
+		return fmt.Errorf("send SASL response: %w", err)
+	}
+
+	// Step 4: Read AuthenticationSASLFinal (type 12)
+	msg, err = protocol.ReadMessage(conn)
+	if err != nil {
+		return fmt.Errorf("read SASL final: %w", err)
+	}
+	if msg.Type == protocol.MsgErrorResponse {
+		return fmt.Errorf("SASL final: auth failed")
+	}
+	if msg.Type != protocol.MsgAuthentication || len(msg.Payload) < 4 {
+		return fmt.Errorf("unexpected message for SASL final: type=%c", msg.Type)
+	}
+	authType := binary.BigEndian.Uint32(msg.Payload[0:4])
+	if authType != 12 {
+		return fmt.Errorf("expected SASLFinal(12), got %d", authType)
+	}
+
+	// Verify server signature
+	serverKey := hmacSHA256(saltedPassword, []byte("Server Key"))
+	expectedServerSig := hmacSHA256(serverKey, []byte(authMessage))
+
+	serverFinalMsg := string(msg.Payload[4:])
+	if !strings.HasPrefix(serverFinalMsg, "v=") {
+		return fmt.Errorf("invalid server-final: %s", serverFinalMsg)
+	}
+	serverSig, err := base64.StdEncoding.DecodeString(serverFinalMsg[2:])
+	if err != nil {
+		return fmt.Errorf("decode server signature: %w", err)
+	}
+	if !hmac.Equal(serverSig, expectedServerSig) {
+		return fmt.Errorf("server signature mismatch")
+	}
+
+	// AuthenticationOk (type 0) will follow, handled by the caller's loop
+	return nil
+}
+
+func parseServerFirst(msg string) (nonce string, salt []byte, iterations int, err error) {
+	parts := strings.Split(msg, ",")
+	for _, p := range parts {
+		if strings.HasPrefix(p, "r=") {
+			nonce = p[2:]
+		} else if strings.HasPrefix(p, "s=") {
+			salt, err = base64.StdEncoding.DecodeString(p[2:])
+			if err != nil {
+				return "", nil, 0, fmt.Errorf("decode salt: %w", err)
+			}
+		} else if strings.HasPrefix(p, "i=") {
+			fmt.Sscanf(p[2:], "%d", &iterations)
+		}
+	}
+	if nonce == "" || salt == nil || iterations == 0 {
+		return "", nil, 0, fmt.Errorf("incomplete server-first-message: %s", msg)
+	}
+	return nonce, salt, iterations, nil
+}
+
+func generateNonce() string {
+	buf := make([]byte, 18)
+	rand.Read(buf)
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func sha256Sum(data []byte) []byte {
+	h := sha256.Sum256(data)
+	return h[:]
+}
+
+func xorBytes(a, b []byte) []byte {
+	result := make([]byte, len(a))
+	for i := range a {
+		result[i] = a[i] ^ b[i]
+	}
+	return result
+}
+
+// pgMD5Password computes the PG MD5 password hash.
+// hash = "md5" + md5(md5(password + user) + salt)
+func pgMD5Password(user, password string, salt []byte) string {
+	h1 := md5.New()
+	h1.Write([]byte(password))
+	h1.Write([]byte(user))
+	inner := fmt.Sprintf("%x", h1.Sum(nil))
+
+	h2 := md5.New()
+	h2.Write([]byte(inner))
+	h2.Write(salt)
+	return "md5" + fmt.Sprintf("%x", h2.Sum(nil))
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -6,24 +6,83 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 
+	"github.com/jyukki97/db-proxy/internal/cache"
 	"github.com/jyukki97/db-proxy/internal/config"
+	"github.com/jyukki97/db-proxy/internal/pool"
 	"github.com/jyukki97/db-proxy/internal/protocol"
+	"github.com/jyukki97/db-proxy/internal/router"
 )
 
 type Server struct {
-	listenAddr string
-	writerAddr string
-	listener   net.Listener
-	wg         sync.WaitGroup
+	cfg         *config.Config
+	listenAddr  string
+	writerAddr  string
+	readerPools map[string]*pool.Pool
+	balancer    *router.RoundRobin
+	queryCache  *cache.Cache
+	listener    net.Listener
+	wg          sync.WaitGroup
 }
 
 func NewServer(cfg *config.Config) *Server {
-	return &Server{
-		listenAddr: cfg.Proxy.Listen,
-		writerAddr: fmt.Sprintf("%s:%d", cfg.Writer.Host, cfg.Writer.Port),
+	writerAddr := fmt.Sprintf("%s:%d", cfg.Writer.Host, cfg.Writer.Port)
+
+	readerAddrs := make([]string, len(cfg.Readers))
+	for i, r := range cfg.Readers {
+		readerAddrs[i] = fmt.Sprintf("%s:%d", r.Host, r.Port)
 	}
+
+	s := &Server{
+		cfg:         cfg,
+		listenAddr:  cfg.Proxy.Listen,
+		writerAddr:  writerAddr,
+		balancer:    router.NewRoundRobin(readerAddrs),
+		readerPools: make(map[string]*pool.Pool),
+	}
+
+	// Initialize query cache
+	if cfg.Cache.Enabled {
+		s.queryCache = cache.New(cache.Config{
+			MaxEntries: cfg.Cache.MaxCacheEntries,
+			TTL:        cfg.Cache.CacheTTL,
+			MaxSize:    parseSize(cfg.Cache.MaxResultSize),
+		})
+		slog.Info("query cache enabled",
+			"max_entries", cfg.Cache.MaxCacheEntries,
+			"ttl", cfg.Cache.CacheTTL)
+	}
+
+	// Initialize reader connection pools (PG-aware via DialFunc)
+	for _, addr := range readerAddrs {
+		addr := addr // capture for closure
+		p, err := pool.New(pool.Config{
+			DialFunc: func() (net.Conn, error) {
+				return pgConnect(addr, cfg.Backend.User, cfg.Backend.Password, cfg.Backend.Database)
+			},
+			MinConnections:    0, // lazy creation; backends may not be ready at startup
+			MaxConnections:    cfg.Pool.MaxConnections,
+			IdleTimeout:       cfg.Pool.IdleTimeout,
+			MaxLifetime:       cfg.Pool.MaxLifetime,
+			ConnectionTimeout: cfg.Pool.ConnectionTimeout,
+		})
+		if err != nil {
+			slog.Error("create reader pool", "addr", addr, "error", err)
+			continue
+		}
+		s.readerPools[addr] = p
+		slog.Info("reader pool created", "addr", addr, "max_conn", cfg.Pool.MaxConnections)
+	}
+
+	slog.Info("server initialized",
+		"writer", writerAddr,
+		"readers", len(readerAddrs),
+		"cache", cfg.Cache.Enabled)
+
+	return s
 }
 
 func (s *Server) Start(ctx context.Context) error {
@@ -33,6 +92,15 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.listener = ln
 	slog.Info("proxy listening", "addr", s.listenAddr)
+
+	// Start reader health checks
+	for addr, p := range s.readerPools {
+		p.StartHealthCheck(ctx, s.cfg.Pool.IdleTimeout/2)
+		slog.Debug("reader health check started", "addr", addr)
+	}
+
+	// Start balancer health check
+	s.balancer.StartHealthCheck(ctx, s.cfg.Pool.ConnectionTimeout)
 
 	go func() {
 		<-ctx.Done()
@@ -45,6 +113,7 @@ func (s *Server) Start(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				s.wg.Wait()
+				s.closeReaderPools()
 				slog.Info("proxy shut down gracefully")
 				return nil
 			default:
@@ -76,12 +145,10 @@ func (s *Server) handleConn(ctx context.Context, clientConn net.Conn) {
 	if len(startup.Payload) >= 4 {
 		code := binary.BigEndian.Uint32(startup.Payload[0:4])
 		if code == protocol.SSLRequestCode {
-			// Send 'N' (SSL not supported)
 			if _, err := clientConn.Write([]byte{'N'}); err != nil {
 				slog.Error("write ssl reject", "error", err)
 				return
 			}
-			// Read the real startup message
 			startup, err = protocol.ReadStartupMessage(clientConn)
 			if err != nil {
 				slog.Error("read startup after ssl reject", "error", err)
@@ -93,37 +160,41 @@ func (s *Server) handleConn(ctx context.Context, clientConn net.Conn) {
 	_, _, params := protocol.ParseStartupParams(startup.Payload)
 	slog.Info("client startup", "user", params["user"], "database", params["database"])
 
-	// 3. Connect to backend DB
-	backendConn, err := net.Dial("tcp", s.writerAddr)
+	// 3. Connect to writer backend (dedicated per client session)
+	writerConn, err := net.Dial("tcp", s.writerAddr)
 	if err != nil {
-		slog.Error("connect to backend", "addr", s.writerAddr, "error", err)
+		slog.Error("connect to writer", "addr", s.writerAddr, "error", err)
 		s.sendError(clientConn, "cannot connect to backend database")
 		return
 	}
-	defer backendConn.Close()
+	defer writerConn.Close()
 
-	// 4. Forward startup message to backend (rebuild with length prefix)
+	// 4. Forward startup message to writer
 	startupRaw := make([]byte, 4+len(startup.Payload))
 	binary.BigEndian.PutUint32(startupRaw[0:4], uint32(4+len(startup.Payload)))
 	copy(startupRaw[4:], startup.Payload)
-	if err := protocol.WriteRaw(backendConn, startupRaw); err != nil {
-		slog.Error("forward startup to backend", "error", err)
+	if err := protocol.WriteRaw(writerConn, startupRaw); err != nil {
+		slog.Error("forward startup to writer", "error", err)
 		return
 	}
 
-	// 5. Relay authentication messages from backend to client until ReadyForQuery
-	if err := s.relayAuth(clientConn, backendConn); err != nil {
+	// 5. Relay authentication between client and writer until ReadyForQuery
+	if err := s.relayAuth(clientConn, writerConn); err != nil {
 		slog.Error("auth relay", "error", err)
 		return
 	}
 
 	slog.Info("handshake complete", "remote", clientConn.RemoteAddr())
 
-	// 6. Relay queries (T2-3)
-	s.relayQueries(ctx, clientConn, backendConn)
+	// 6. Create per-client session router
+	session := router.NewSession(s.cfg.Routing.ReadAfterWriteDelay)
+
+	// 7. Relay queries with routing and caching
+	s.relayQueries(ctx, clientConn, writerConn, session)
 }
 
-// relayAuth forwards all messages from backend to client until ReadyForQuery ('Z').
+// relayAuth relays the full bidirectional authentication flow between client and backend.
+// Backend sends auth challenges → proxy forwards to client → client responds → proxy forwards to backend.
 func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
 	for {
 		msg, err := protocol.ReadMessage(backendConn)
@@ -142,13 +213,41 @@ func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
 		if msg.Type == protocol.MsgReadyForQuery {
 			return nil
 		}
+
+		// If backend requests authentication, read client's response and forward to backend
+		if msg.Type == protocol.MsgAuthentication && len(msg.Payload) >= 4 {
+			authType := binary.BigEndian.Uint32(msg.Payload[0:4])
+			if authNeedsResponse(authType) {
+				clientMsg, err := protocol.ReadMessage(clientConn)
+				if err != nil {
+					return fmt.Errorf("read client auth response: %w", err)
+				}
+				if err := protocol.WriteMessage(backendConn, clientMsg.Type, clientMsg.Payload); err != nil {
+					return fmt.Errorf("forward client auth to backend: %w", err)
+				}
+			}
+		}
 	}
 }
 
-// relayQueries reads client messages one at a time, forwards to backend,
-// and relays backend responses back to client. Message-level relay enables
-// future routing/caching hooks.
-func (s *Server) relayQueries(ctx context.Context, clientConn, backendConn net.Conn) {
+// authNeedsResponse returns true if the PG auth type requires a client response.
+func authNeedsResponse(authType uint32) bool {
+	switch authType {
+	case 3: // CleartextPassword
+		return true
+	case 5: // MD5Password
+		return true
+	case 10: // SASL (SCRAM-SHA-256 init)
+		return true
+	case 11: // SASLContinue
+		return true
+	default: // 0 (Ok), 12 (SASLFinal), etc.
+		return false
+	}
+}
+
+// relayQueries handles the main query loop with R/W routing and caching.
+func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Conn, session *router.Session) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -156,37 +255,132 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, backendConn net.C
 		default:
 		}
 
-		// Read one message from client
 		msg, err := protocol.ReadMessage(clientConn)
 		if err != nil {
 			slog.Debug("client disconnected", "error", err)
 			return
 		}
 
-		// Terminate message — close session
 		if msg.Type == protocol.MsgTerminate {
 			slog.Info("client terminated", "remote", clientConn.RemoteAddr())
 			return
 		}
 
-		// Extract query text for logging (Query messages: SQL + null terminator)
-		if msg.Type == protocol.MsgQuery {
-			query := protocol.ExtractQueryText(msg.Payload)
-			slog.Debug("query", "sql", query)
+		// Extended Query Protocol: Parse(P), Bind(B), Describe(D), Execute(E), Close(C)
+		// These are buffered by the backend until Sync(S) triggers ReadyForQuery.
+		if msg.Type != protocol.MsgQuery {
+			if err := protocol.WriteMessage(writerConn, msg.Type, msg.Payload); err != nil {
+				slog.Error("forward to writer", "error", err)
+				return
+			}
+			// Only relay responses after Sync — that's when backend sends ReadyForQuery
+			if msg.Type == protocol.MsgSync {
+				if err := s.relayUntilReady(clientConn, writerConn); err != nil {
+					slog.Error("relay writer response (sync)", "error", err)
+					return
+				}
+			}
+			continue
 		}
 
-		// Forward message to backend
-		if err := protocol.WriteMessage(backendConn, msg.Type, msg.Payload); err != nil {
-			slog.Error("forward to backend", "error", err)
-			return
-		}
+		query := protocol.ExtractQueryText(msg.Payload)
+		route := session.Route(query)
+		slog.Debug("query routed", "sql", query, "route", routeName(route))
 
-		// Relay backend responses until ReadyForQuery
-		if err := s.relayUntilReady(clientConn, backendConn); err != nil {
-			slog.Error("relay backend response", "error", err)
-			return
+		if route == router.RouteWriter {
+			s.handleWriteQuery(clientConn, writerConn, msg, query)
+		} else {
+			if err := s.handleReadQuery(ctx, clientConn, writerConn, msg, query); err != nil {
+				slog.Error("handle read query", "error", err)
+				return
+			}
 		}
 	}
+}
+
+// handleWriteQuery forwards a write query to the writer and invalidates cache.
+func (s *Server) handleWriteQuery(clientConn, writerConn net.Conn, msg *protocol.Message, query string) {
+	if err := s.forwardAndRelay(clientConn, writerConn, msg); err != nil {
+		slog.Error("forward write to writer", "error", err)
+		return
+	}
+
+	// Invalidate cache for affected tables
+	if s.queryCache != nil && router.Classify(query) == router.QueryWrite {
+		tables := router.ExtractTables(query)
+		for _, table := range tables {
+			s.queryCache.InvalidateTable(table)
+			slog.Debug("cache invalidated", "table", table)
+		}
+	}
+}
+
+// handleReadQuery checks cache, acquires a reader from pool, or falls back to writer.
+func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net.Conn, msg *protocol.Message, query string) error {
+	// Check cache
+	if s.queryCache != nil {
+		key := cache.CacheKey(query)
+		if cached := s.queryCache.Get(key); cached != nil {
+			slog.Debug("cache hit", "sql", query)
+			_, err := clientConn.Write(cached)
+			return err
+		}
+	}
+
+	// Try to acquire a reader connection from pool
+	readerAddr := s.balancer.Next()
+	if readerAddr == "" {
+		slog.Warn("no healthy reader, fallback to writer")
+		return s.forwardAndRelay(clientConn, writerConn, msg)
+	}
+
+	rPool, ok := s.readerPools[readerAddr]
+	if !ok {
+		slog.Warn("no pool for reader, fallback to writer", "addr", readerAddr)
+		return s.forwardAndRelay(clientConn, writerConn, msg)
+	}
+
+	rConn, err := rPool.Acquire(ctx)
+	if err != nil {
+		slog.Warn("acquire reader failed, fallback to writer", "addr", readerAddr, "error", err)
+		return s.forwardAndRelay(clientConn, writerConn, msg)
+	}
+
+	// Forward query to reader
+	if err := protocol.WriteMessage(rConn, msg.Type, msg.Payload); err != nil {
+		slog.Error("forward to reader", "addr", readerAddr, "error", err)
+		rPool.Discard(rConn)
+		// Fallback to writer
+		return s.forwardAndRelay(clientConn, writerConn, msg)
+	}
+
+	// Relay response and collect bytes for caching
+	if s.queryCache != nil {
+		collected, err := s.relayAndCollect(clientConn, rConn)
+		rPool.Release(rConn)
+		if err != nil {
+			return fmt.Errorf("relay reader response: %w", err)
+		}
+		key := cache.CacheKey(query)
+		s.queryCache.Set(key, collected, nil)
+		slog.Debug("cache set", "sql", query, "size", len(collected))
+	} else {
+		if err := s.relayUntilReady(clientConn, rConn); err != nil {
+			rPool.Discard(rConn)
+			return fmt.Errorf("relay reader response: %w", err)
+		}
+		rPool.Release(rConn)
+	}
+
+	return nil
+}
+
+// forwardAndRelay forwards a message to backend and relays the response to client.
+func (s *Server) forwardAndRelay(clientConn, backendConn net.Conn, msg *protocol.Message) error {
+	if err := protocol.WriteMessage(backendConn, msg.Type, msg.Payload); err != nil {
+		return fmt.Errorf("forward message: %w", err)
+	}
+	return s.relayUntilReady(clientConn, backendConn)
 }
 
 // relayUntilReady forwards backend messages to client until ReadyForQuery ('Z').
@@ -207,8 +401,35 @@ func (s *Server) relayUntilReady(clientConn, backendConn net.Conn) error {
 	}
 }
 
+// relayAndCollect relays backend responses to client and collects all bytes for caching.
+func (s *Server) relayAndCollect(clientConn, backendConn net.Conn) ([]byte, error) {
+	var buf []byte
+	for {
+		msg, err := protocol.ReadMessage(backendConn)
+		if err != nil {
+			return nil, fmt.Errorf("read backend response: %w", err)
+		}
+
+		// Serialize message to wire format
+		msgBytes := make([]byte, 1+4+len(msg.Payload))
+		msgBytes[0] = msg.Type
+		binary.BigEndian.PutUint32(msgBytes[1:5], uint32(4+len(msg.Payload)))
+		copy(msgBytes[5:], msg.Payload)
+
+		// Forward to client
+		if _, err := clientConn.Write(msgBytes); err != nil {
+			return nil, fmt.Errorf("forward to client: %w", err)
+		}
+
+		buf = append(buf, msgBytes...)
+
+		if msg.Type == protocol.MsgReadyForQuery {
+			return buf, nil
+		}
+	}
+}
+
 func (s *Server) sendError(conn net.Conn, msg string) {
-	// PG ErrorResponse: 'E' + length + severity + message + terminator
 	var payload []byte
 	payload = append(payload, 'S')
 	payload = append(payload, []byte("ERROR")...)
@@ -218,4 +439,33 @@ func (s *Server) sendError(conn net.Conn, msg string) {
 	payload = append(payload, 0)
 	payload = append(payload, 0) // terminator
 	protocol.WriteMessage(conn, protocol.MsgErrorResponse, payload)
+}
+
+func (s *Server) closeReaderPools() {
+	for addr, p := range s.readerPools {
+		p.Close()
+		slog.Debug("reader pool closed", "addr", addr)
+	}
+}
+
+func routeName(r router.Route) string {
+	if r == router.RouteWriter {
+		return "writer"
+	}
+	return "reader"
+}
+
+// parseSize converts a size string like "512KB" or "1MB" to bytes.
+func parseSize(s string) int {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	if strings.HasSuffix(s, "MB") {
+		n, _ := strconv.Atoi(strings.TrimSuffix(s, "MB"))
+		return n * 1024 * 1024
+	}
+	if strings.HasSuffix(s, "KB") {
+		n, _ := strconv.Atoi(strings.TrimSuffix(s, "KB"))
+		return n * 1024
+	}
+	n, _ := strconv.Atoi(s)
+	return n
 }

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -13,6 +13,30 @@ func testConfig(listen string) *config.Config {
 	return &config.Config{
 		Proxy:  config.ProxyConfig{Listen: listen},
 		Writer: config.DBConfig{Host: "127.0.0.1", Port: 5432},
+		Readers: []config.DBConfig{
+			{Host: "127.0.0.1", Port: 5433},
+		},
+		Pool: config.PoolConfig{
+			MinConnections:    0,
+			MaxConnections:    10,
+			IdleTimeout:       10 * time.Minute,
+			MaxLifetime:       time.Hour,
+			ConnectionTimeout: 5 * time.Second,
+		},
+		Routing: config.RoutingConfig{
+			ReadAfterWriteDelay: 500 * time.Millisecond,
+		},
+		Cache: config.CacheConfig{
+			Enabled:         false, // disable cache for unit tests
+			CacheTTL:        10 * time.Second,
+			MaxCacheEntries: 1000,
+			MaxResultSize:   "1MB",
+		},
+		Backend: config.BackendConfig{
+			User:     "postgres",
+			Password: "postgres",
+			Database: "testdb",
+		},
 	}
 }
 
@@ -73,5 +97,24 @@ func TestServer_GracefulShutdown(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("shutdown timed out")
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"512KB", 512 * 1024},
+		{"1MB", 1024 * 1024},
+		{"1024", 1024},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		got := parseSize(tt.input)
+		if got != tt.want {
+			t.Errorf("parseSize(%q) = %d, want %d", tt.input, got, tt.want)
+		}
 	}
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// TestE2E_ProxyIntegration tests the full proxy with real PostgreSQL backends.
+// Requires: docker-compose up && go run ./cmd/db-proxy config.test.yaml
+func TestE2E_ProxyIntegration(t *testing.T) {
+	proxyDSN := "postgres://postgres:postgres@127.0.0.1:15440/testdb?sslmode=disable"
+
+	// Check if proxy is reachable
+	db, err := sql.Open("postgres", proxyDSN)
+	if err != nil {
+		t.Skipf("cannot open proxy connection: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Skipf("proxy not reachable (start docker-compose + proxy first): %v", err)
+	}
+
+	t.Run("ReadQuery", func(t *testing.T) {
+		rows, err := db.QueryContext(ctx, "SELECT name FROM users ORDER BY id LIMIT 3")
+		if err != nil {
+			t.Fatalf("SELECT failed: %v", err)
+		}
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				t.Fatal(err)
+			}
+			names = append(names, name)
+		}
+
+		if len(names) < 3 {
+			t.Fatalf("got %d rows, want >= 3", len(names))
+		}
+		if names[0] != "alice" || names[1] != "bob" || names[2] != "charlie" {
+			t.Errorf("got names %v, want [alice bob charlie]", names)
+		}
+		t.Logf("Read query OK: %v (routed to reader via RoundRobin)", names)
+	})
+
+	t.Run("WriteQuery", func(t *testing.T) {
+		_, err := db.ExecContext(ctx, "INSERT INTO users (name, email) VALUES ($1, $2)", "dave", "dave@example.com")
+		if err != nil {
+			t.Fatalf("INSERT failed: %v", err)
+		}
+
+		// Read back
+		var count int
+		err = db.QueryRowContext(ctx, "SELECT count(*) FROM users").Scan(&count)
+		if err != nil {
+			t.Fatalf("count query failed: %v", err)
+		}
+		if count < 4 {
+			t.Errorf("got count %d, want >= 4", count)
+		}
+		t.Logf("Write query OK: count=%d", count)
+
+		// Clean up
+		db.ExecContext(ctx, "DELETE FROM users WHERE name = 'dave'")
+	})
+
+	t.Run("Transaction", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BEGIN failed: %v", err)
+		}
+
+		_, err = tx.ExecContext(ctx, "INSERT INTO users (name, email) VALUES ('tx_user', 'tx@example.com')")
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("INSERT in tx failed: %v", err)
+		}
+
+		// Read within same transaction should see the insert
+		var name string
+		err = tx.QueryRowContext(ctx, "SELECT name FROM users WHERE name = 'tx_user'").Scan(&name)
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("SELECT in tx failed: %v", err)
+		}
+		if name != "tx_user" {
+			t.Errorf("got name %q, want 'tx_user'", name)
+		}
+
+		tx.Rollback()
+		t.Log("Transaction routing OK")
+	})
+
+	t.Run("CacheHit", func(t *testing.T) {
+		// First query - cache miss
+		var name1 string
+		err := db.QueryRowContext(ctx, "SELECT name FROM users WHERE id = 1").Scan(&name1)
+		if err != nil {
+			t.Fatalf("first SELECT failed: %v", err)
+		}
+
+		// Second identical query - should be cache hit
+		var name2 string
+		err = db.QueryRowContext(ctx, "SELECT name FROM users WHERE id = 1").Scan(&name2)
+		if err != nil {
+			t.Fatalf("second SELECT failed: %v", err)
+		}
+
+		if name1 != name2 {
+			t.Errorf("cache inconsistency: %q != %q", name1, name2)
+		}
+		t.Logf("Cache test OK: %s", name1)
+	})
+}
+
+// TestE2E_ProxyStartStop tests that the proxy binary starts and stops cleanly.
+func TestE2E_ProxyStartStop(t *testing.T) {
+	if os.Getenv("E2E") == "" {
+		t.Skip("set E2E=1 to run")
+	}
+
+	binPath := "../bin/db-proxy"
+	cfgPath := "../config.test.yaml"
+
+	cmd := exec.Command(binPath, cfgPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+
+	time.Sleep(time.Second)
+
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("send interrupt: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Logf("proxy exited with: %v (expected for signal)", err)
+		}
+	case <-time.After(5 * time.Second):
+		cmd.Process.Kill()
+		t.Fatal("proxy did not shut down within 5s")
+	}
+
+	fmt.Println("proxy start/stop OK")
+}


### PR DESCRIPTION
## Summary
- proxy/server.go 전면 재작성: Pool, Router(Session+RoundRobin), Cache를 프록시에 통합
- PG 인증 직접 구현 (MD5 + SCRAM-SHA-256) → Reader Pool의 DialFunc으로 사용
- Auth relay 양방향 수정, Extended Query Protocol 지원
- Docker 환경 E2E 테스트 4건 추가 (ReadQuery, WriteQuery, Transaction, CacheHit)

## 변경 파일
| 파일 | 내용 |
|------|------|
| `proxy/server.go` | Pool+Router+Cache 통합, 쿼리 라우팅 플로우 |
| `proxy/pgconn.go` | 신규 - PG 연결 + MD5/SCRAM-SHA-256 인증 |
| `pool/pool.go` | DialFunc 지원 + Discard() 추가 |
| `config/config.go` | BackendConfig 추가 |
| `tests/e2e_test.go` | 신규 - Docker E2E 테스트 |
| `cmd/db-proxy/main.go` | -debug 플래그 |

## Test plan
- [x] `go test ./... -count=1` 전체 통과 (73건)
- [x] `go test -bench=. -benchmem ./tests/` 벤치마크 정상
- [x] Docker Compose (Primary + Replica x2) E2E 테스트 통과
- [x] 프록시 디버그 로그로 R/W 라우팅 + 캐시 동작 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)