### PR TITLE
fix(protocol): ReadMessage OOM DoS 방지 — 최대 메시지 크기 제한

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -33,6 +33,10 @@ const (
 // SSLRequestCode is the magic number for SSL negotiation
 const SSLRequestCode = 80877103
 
+// MaxMessageSize is the maximum allowed payload size for a single PG message (16 MB).
+// Prevents OOM from malicious length headers.
+const MaxMessageSize = 16 * 1024 * 1024
+
 // Message represents a PG wire protocol message.
 // For startup messages, Type is 0.
 type Message struct {
@@ -76,7 +80,12 @@ func ReadMessage(r io.Reader) (*Message, error) {
 		return nil, fmt.Errorf("invalid message length: %d", length)
 	}
 
-	payload := make([]byte, length-4)
+	payloadLen := int(length - 4)
+	if payloadLen > MaxMessageSize {
+		return nil, fmt.Errorf("message too large: %d bytes (max %d)", payloadLen, MaxMessageSize)
+	}
+
+	payload := make([]byte, payloadLen)
 	if len(payload) > 0 {
 		if _, err := io.ReadFull(r, payload); err != nil {
 			return nil, fmt.Errorf("read message payload: %w", err)

--- a/internal/protocol/protocol_edge_test.go
+++ b/internal/protocol/protocol_edge_test.go
@@ -1,0 +1,56 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestReadMessage_MaxSizeExceeded(t *testing.T) {
+	// Simulate a malicious client sending a 1GB length header
+	buf := new(bytes.Buffer)
+	buf.WriteByte('Q')
+	binary.Write(buf, binary.BigEndian, int32(1024*1024*1024)) // 1GB
+
+	_, err := ReadMessage(buf)
+	if err == nil {
+		t.Fatal("expected error for extremely large message, got nil")
+	}
+	if !strings.Contains(err.Error(), "message too large") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestReadMessage_ExactlyMaxSize(t *testing.T) {
+	// A message at exactly MaxMessageSize should be accepted (not rejected)
+	// We don't actually write MaxMessageSize bytes — just verify the length check passes.
+	// The read will fail at io.ReadFull because the buffer is empty, but it should NOT
+	// fail at the size check.
+	buf := new(bytes.Buffer)
+	buf.WriteByte('Q')
+	binary.Write(buf, binary.BigEndian, int32(MaxMessageSize+4)) // payload = MaxMessageSize
+
+	_, err := ReadMessage(buf)
+	if err == nil {
+		t.Fatal("expected error (incomplete read), got nil")
+	}
+	// Should fail at read, not at size check
+	if strings.Contains(err.Error(), "message too large") {
+		t.Errorf("MaxMessageSize payload should be accepted, got: %v", err)
+	}
+}
+
+func TestReadMessage_JustOverMaxSize(t *testing.T) {
+	buf := new(bytes.Buffer)
+	buf.WriteByte('Q')
+	binary.Write(buf, binary.BigEndian, int32(MaxMessageSize+5)) // payload = MaxMessageSize+1
+
+	_, err := ReadMessage(buf)
+	if err == nil {
+		t.Fatal("expected error for over-max message, got nil")
+	}
+	if !strings.Contains(err.Error(), "message too large") {
+		t.Errorf("expected 'message too large' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `ReadMessage()`에 `MaxMessageSize` (16MB) 상한 검사 추가
- 공격자가 length header에 1GB 등 거대 값을 보내도 `make()` 전에 에러 반환
- 인증 전 단일 패킷으로 프록시 OOM 크래시 가능한 CRITICAL 취약점 수정

Closes #31

## Test plan
- [x] `TestReadMessage_MaxSizeExceeded` — 1GB length header → 에러 반환 확인
- [x] `TestReadMessage_ExactlyMaxSize` — 정확히 16MB → size check 통과 확인
- [x] `TestReadMessage_JustOverMaxSize` — 16MB+1 → 에러 반환 확인
- [x] 기존 프로토콜 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)