### PR TITLE
feat(proxy): Transaction Pooling - Writer 커넥션 다중화

### DIFF
--- a/cmd/db-proxy/main.go
+++ b/cmd/db-proxy/main.go
@@ -61,7 +61,7 @@ func run() error {
 
 	// Start Admin API server
 	if cfg.Admin.Enabled {
-		adminSrv := admin.New(cfg, srv.Cache(), srv.Invalidator(), srv.ReaderPools())
+		adminSrv := admin.New(cfg, srv.Cache(), srv.Invalidator(), srv.WriterPool(), srv.ReaderPools())
 		go func() {
 			if err := adminSrv.ListenAndServe(cfg.Admin.Listen); err != nil && err != http.ErrServerClosed {
 				slog.Error("admin server error", "error", err)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,6 +141,7 @@ pool:
   idle_timeout: "10m"
   max_lifetime: "1h"
   connection_timeout: "5s"
+  reset_query: "DISCARD ALL"
 
 routing:
   read_after_write_delay: "500ms"
@@ -164,3 +165,10 @@ admin:
   enabled: true
   listen: "0.0.0.0:9091"
 ```
+### 7. 향후 고도화 아이디어 (Future Enhancements)
+- **Transaction/Statement Pooling**: 클라이언트 커넥션을 다중화하여 백엔드 커넥션을 극단적으로 절약하는 진정한 Connection Multiplexing.
+- **SSL/TLS Termination**: 프록시에 인증서를 탑재하여 보안 통신 지원.
+- **Circuit Breaker & Rate Limiting**: DB 과부하 시 연쇄 장애 방어 및 악성 유저 Throttling.
+- **AST 기반 쿼리 제어**: pg_query_go 등을 활용한 완벽한 쿼리 파싱 및 위험 쿼리(예: 조건 없는 DELETE) 방화벽(Firewall).
+- **분산 추적 (OpenTelemetry)**: 쿼리가 프록시를 거쳐 처리되는 전 과정을 모니터링하기 위한 Trace ID 삽입.
+- **무중단 리로드 (Zero-Downtime Reload)**: SIGHUP 등을 통한 안전한 설정/커넥션 풀 동적 교체 기능.

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -20,16 +20,18 @@ type Server struct {
 	cfg         *config.Config
 	cache       *cache.Cache
 	invalidator *cache.Invalidator
+	writerPool  *pool.Pool
 	readerPools map[string]*pool.Pool
 	mu          sync.RWMutex
 }
 
 // New creates a new Admin server.
-func New(cfg *config.Config, c *cache.Cache, inv *cache.Invalidator, readerPools map[string]*pool.Pool) *Server {
+func New(cfg *config.Config, c *cache.Cache, inv *cache.Invalidator, writerPool *pool.Pool, readerPools map[string]*pool.Pool) *Server {
 	return &Server{
 		cfg:         cfg,
 		cache:       c,
 		invalidator: inv,
+		writerPool:  writerPool,
 		readerPools: readerPools,
 	}
 }
@@ -86,13 +88,28 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	poolStats := make(map[string]any)
+
+	// Writer pool stats
+	if s.writerPool != nil {
+		wOpen, wIdle := s.writerPool.Stats()
+		writerAddr := fmt.Sprintf("%s:%d", s.cfg.Writer.Host, s.cfg.Writer.Port)
+		poolStats["writer"] = map[string]any{
+			"addr": writerAddr,
+			"open": wOpen,
+			"idle": wIdle,
+		}
+	}
+
+	// Reader pool stats
+	readerStats := make(map[string]any)
 	for addr, p := range s.readerPools {
 		open, idle := p.Stats()
-		poolStats[addr] = map[string]any{
+		readerStats[addr] = map[string]any{
 			"open": open,
 			"idle": idle,
 		}
 	}
+	poolStats["readers"] = readerStats
 
 	cacheStats := map[string]any{
 		"enabled": s.cache != nil,

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -43,7 +43,7 @@ func testServer() *Server {
 		TTL:        10 * time.Second,
 	})
 
-	return New(cfg, c, nil, map[string]*pool.Pool{})
+	return New(cfg, c, nil, nil, map[string]*pool.Pool{})
 }
 
 func TestHandleHealth(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type PoolConfig struct {
 	IdleTimeout       time.Duration `yaml:"idle_timeout"`
 	MaxLifetime       time.Duration `yaml:"max_lifetime"`
 	ConnectionTimeout time.Duration `yaml:"connection_timeout"`
+	ResetQuery        string        `yaml:"reset_query"`
 }
 
 type RoutingConfig struct {
@@ -121,6 +122,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Cache.MaxResultSize == "" {
 		c.Cache.MaxResultSize = "1MB"
+	}
+	if c.Pool.ResetQuery == "" {
+		c.Pool.ResetQuery = "DISCARD ALL"
 	}
 	if c.Cache.Invalidation.Mode == "" {
 		c.Cache.Invalidation.Mode = "local"

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -20,16 +20,17 @@ import (
 )
 
 type Server struct {
-	cfg          *config.Config
-	listenAddr   string
-	writerAddr   string
-	readerPools  map[string]*pool.Pool
-	balancer     *router.RoundRobin
-	queryCache   *cache.Cache
-	invalidator  *cache.Invalidator
-	metrics      *metrics.Metrics
-	listener     net.Listener
-	wg           sync.WaitGroup
+	cfg         *config.Config
+	listenAddr  string
+	writerAddr  string
+	writerPool  *pool.Pool
+	readerPools map[string]*pool.Pool
+	balancer    *router.RoundRobin
+	queryCache  *cache.Cache
+	invalidator *cache.Invalidator
+	metrics     *metrics.Metrics
+	listener    net.Listener
+	wg          sync.WaitGroup
 }
 
 func NewServer(cfg *config.Config) *Server {
@@ -84,6 +85,24 @@ func NewServer(cfg *config.Config) *Server {
 		}
 	}
 
+	// Initialize writer connection pool
+	writerPool, err := pool.New(pool.Config{
+		DialFunc: func() (net.Conn, error) {
+			return pgConnect(writerAddr, cfg.Backend.User, cfg.Backend.Password, cfg.Backend.Database)
+		},
+		MinConnections:    0, // lazy creation; backend may not be ready at startup
+		MaxConnections:    cfg.Pool.MaxConnections,
+		IdleTimeout:       cfg.Pool.IdleTimeout,
+		MaxLifetime:       cfg.Pool.MaxLifetime,
+		ConnectionTimeout: cfg.Pool.ConnectionTimeout,
+	})
+	if err != nil {
+		slog.Error("create writer pool", "addr", writerAddr, "error", err)
+	} else {
+		s.writerPool = writerPool
+		slog.Info("writer pool created", "addr", writerAddr, "max_conn", cfg.Pool.MaxConnections)
+	}
+
 	// Initialize reader connection pools (PG-aware via DialFunc)
 	for _, addr := range readerAddrs {
 		addr := addr // capture for closure
@@ -108,7 +127,8 @@ func NewServer(cfg *config.Config) *Server {
 	slog.Info("server initialized",
 		"writer", writerAddr,
 		"readers", len(readerAddrs),
-		"cache", cfg.Cache.Enabled)
+		"cache", cfg.Cache.Enabled,
+		"pooling", "transaction")
 
 	return s
 }
@@ -120,6 +140,12 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.listener = ln
 	slog.Info("proxy listening", "addr", s.listenAddr)
+
+	// Start writer pool health check
+	if s.writerPool != nil {
+		s.writerPool.StartHealthCheck(ctx, s.cfg.Pool.IdleTimeout/2)
+		slog.Debug("writer health check started", "addr", s.writerAddr)
+	}
 
 	// Start reader health checks
 	for addr, p := range s.readerPools {
@@ -146,7 +172,7 @@ func (s *Server) Start(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				s.wg.Wait()
-				s.closeReaderPools()
+				s.closePools()
 				if s.invalidator != nil {
 					s.invalidator.Close()
 				}
@@ -196,37 +222,44 @@ func (s *Server) handleConn(ctx context.Context, clientConn net.Conn) {
 	_, _, params := protocol.ParseStartupParams(startup.Payload)
 	slog.Info("client startup", "user", params["user"], "database", params["database"])
 
-	// 3. Connect to writer backend (dedicated per client session)
-	writerConn, err := net.Dial("tcp", s.writerAddr)
+	// 3. Authenticate client via temporary backend connection.
+	//    Pool connections are pre-authenticated via pgConnect(), so we only need
+	//    a temporary connection to relay the client's auth handshake.
+	authConn, err := net.Dial("tcp", s.writerAddr)
 	if err != nil {
-		slog.Error("connect to writer", "addr", s.writerAddr, "error", err)
+		slog.Error("connect to writer for auth", "addr", s.writerAddr, "error", err)
 		s.sendError(clientConn, "cannot connect to backend database")
 		return
 	}
-	defer writerConn.Close()
 
-	// 4. Forward startup message to writer
+	// Forward startup message to auth connection
 	startupRaw := make([]byte, 4+len(startup.Payload))
 	binary.BigEndian.PutUint32(startupRaw[0:4], uint32(4+len(startup.Payload)))
 	copy(startupRaw[4:], startup.Payload)
-	if err := protocol.WriteRaw(writerConn, startupRaw); err != nil {
+	if err := protocol.WriteRaw(authConn, startupRaw); err != nil {
+		authConn.Close()
 		slog.Error("forward startup to writer", "error", err)
 		return
 	}
 
-	// 5. Relay authentication between client and writer until ReadyForQuery
-	if err := s.relayAuth(clientConn, writerConn); err != nil {
+	// Relay authentication between client and auth connection
+	if err := s.relayAuth(clientConn, authConn); err != nil {
+		authConn.Close()
 		slog.Error("auth relay", "error", err)
 		return
 	}
 
+	// Auth complete — close temporary connection.
+	// All further queries use pooled connections.
+	authConn.Close()
+
 	slog.Info("handshake complete", "remote", clientConn.RemoteAddr())
 
-	// 6. Create per-client session router
+	// 4. Create per-client session router
 	session := router.NewSession(s.cfg.Routing.ReadAfterWriteDelay)
 
-	// 7. Relay queries with routing and caching
-	s.relayQueries(ctx, clientConn, writerConn, session)
+	// 5. Relay queries with transaction-level pooling
+	s.relayQueries(ctx, clientConn, session)
 }
 
 // relayAuth relays the full bidirectional authentication flow between client and backend.
@@ -282,12 +315,23 @@ func authNeedsResponse(authType uint32) bool {
 	}
 }
 
-// relayQueries handles the main query loop with R/W routing and caching.
-func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Conn, session *router.Session) {
-	// extBuf collects Extended Query messages destined for a reader, flushed on Sync.
+// relayQueries handles the main query loop with transaction-level connection pooling.
+// Writer connections are acquired from writerPool per query/transaction and released back.
+func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session *router.Session) {
+	// boundWriter is non-nil when a transaction is in progress.
+	// The connection stays bound from BEGIN until COMMIT/ROLLBACK.
+	var boundWriter *pool.Conn
+
+	defer func() {
+		if boundWriter != nil {
+			s.resetAndReleaseWriter(boundWriter)
+		}
+	}()
+
+	// Extended Query protocol state
 	var extBuf []*protocol.Message
 	var extRoute router.Route
-	var extReaderAddr string
+	var extTxStart, extTxEnd bool
 
 	for {
 		select {
@@ -310,16 +354,42 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Co
 		// --- Simple Query Protocol ---
 		if msg.Type == protocol.MsgQuery {
 			query := protocol.ExtractQueryText(msg.Payload)
+
+			wasInTx := session.InTransaction()
 			route := session.Route(query)
+			nowInTx := session.InTransaction()
+
 			target := routeName(route)
 			slog.Debug("query routed", "sql", query, "route", target)
 
 			start := time.Now()
 
 			if route == router.RouteWriter {
-				s.handleWriteQuery(clientConn, writerConn, msg, query)
+				wConn, acquired, err := s.acquireWriterConn(ctx, boundWriter)
+				if err != nil {
+					slog.Error("acquire writer", "error", err)
+					s.sendError(clientConn, "cannot acquire backend connection")
+					return
+				}
+
+				s.handleWriteQuery(clientConn, wConn, msg, query)
+
+				// Transaction lifecycle management
+				switch {
+				case !wasInTx && nowInTx:
+					// BEGIN — bind writer for transaction duration
+					boundWriter = wConn
+				case wasInTx && !nowInTx:
+					// COMMIT/ROLLBACK — unbind and release
+					boundWriter = nil
+					s.resetAndReleaseWriter(wConn)
+				case acquired:
+					// Single statement outside transaction — release immediately
+					s.resetAndReleaseWriter(wConn)
+				}
+				// If !acquired && still in transaction → keep using boundWriter
 			} else {
-				if err := s.handleReadQuery(ctx, clientConn, writerConn, msg, query); err != nil {
+				if err := s.handleReadQuery(ctx, clientConn, msg, query); err != nil {
 					slog.Error("handle read query", "error", err)
 					return
 				}
@@ -339,7 +409,16 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Co
 			route := session.RegisterStatement(stmtName, query)
 			slog.Debug("parse registered", "stmt", stmtName, "sql", query, "route", routeName(route))
 
-			if session.InTransaction() || route == router.RouteWriter {
+			// Track transaction lifecycle in Extended Query
+			upper := strings.ToUpper(strings.TrimSpace(query))
+			if strings.HasPrefix(upper, "BEGIN") || strings.HasPrefix(upper, "START TRANSACTION") {
+				extTxStart = true
+			}
+			if strings.HasPrefix(upper, "COMMIT") || strings.HasPrefix(upper, "ROLLBACK") || strings.HasPrefix(upper, "END") {
+				extTxEnd = true
+			}
+
+			if session.InTransaction() || boundWriter != nil || route == router.RouteWriter {
 				extRoute = router.RouteWriter
 			} else {
 				extRoute = route
@@ -366,28 +445,66 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Co
 			start := time.Now()
 			target := routeName(extRoute)
 
-			if extRoute == router.RouteReader && !session.InTransaction() {
-				// Try to send buffered messages to a reader
-				extReaderAddr = s.balancer.Next()
-				if err := s.handleExtendedRead(ctx, clientConn, writerConn, extBuf, msg, extReaderAddr); err != nil {
+			if extRoute == router.RouteReader && !session.InTransaction() && boundWriter == nil {
+				// Reader path
+				readerAddr := s.balancer.Next()
+				if err := s.handleExtendedRead(ctx, clientConn, extBuf, msg, readerAddr); err != nil {
 					slog.Error("extended read query", "error", err)
 					return
 				}
 			} else {
-				// Send to writer
-				for _, m := range extBuf {
-					if err := protocol.WriteMessage(writerConn, m.Type, m.Payload); err != nil {
-						slog.Error("forward ext to writer", "error", err)
-						return
+				// Writer path — acquire from pool or use bound connection
+				wConn, acquired, err := s.acquireWriterConn(ctx, boundWriter)
+				if err != nil {
+					slog.Error("acquire writer for extended query", "error", err)
+					s.sendError(clientConn, "cannot acquire backend connection")
+					return
+				}
+
+				// Forward all buffered messages + Sync to writer
+				writeErr := s.forwardExtBatch(wConn, extBuf, msg)
+				if writeErr != nil {
+					slog.Error("forward ext batch to writer", "error", writeErr)
+					if acquired {
+						s.writerPool.Discard(wConn)
+					} else if boundWriter != nil {
+						s.writerPool.Discard(boundWriter)
+						boundWriter = nil
 					}
-				}
-				if err := protocol.WriteMessage(writerConn, msg.Type, msg.Payload); err != nil {
-					slog.Error("forward sync to writer", "error", err)
 					return
 				}
-				if err := s.relayUntilReady(clientConn, writerConn); err != nil {
+
+				if err := s.relayUntilReady(clientConn, wConn); err != nil {
 					slog.Error("relay writer response (sync)", "error", err)
+					if acquired {
+						s.writerPool.Discard(wConn)
+					} else if boundWriter != nil {
+						s.writerPool.Discard(boundWriter)
+						boundWriter = nil
+					}
 					return
+				}
+
+				// Update transaction state for Extended Query
+				if extTxStart {
+					session.SetInTransaction(true)
+				}
+				if extTxEnd {
+					session.SetInTransaction(false)
+				}
+
+				// Transaction lifecycle
+				switch {
+				case extTxStart && !extTxEnd:
+					// BEGIN — bind writer
+					boundWriter = wConn
+				case extTxEnd:
+					// COMMIT/ROLLBACK — unbind and release
+					boundWriter = nil
+					s.resetAndReleaseWriter(wConn)
+				case acquired:
+					// Single batch outside transaction — release
+					s.resetAndReleaseWriter(wConn)
 				}
 			}
 
@@ -399,7 +516,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Co
 			// Reset batch state
 			extBuf = extBuf[:0]
 			extRoute = router.RouteReader
-			extReaderAddr = ""
+			extTxStart, extTxEnd = false, false
 
 		default:
 			// Describe(D), Execute(E), etc. — buffer them
@@ -408,8 +525,77 @@ func (s *Server) relayQueries(ctx context.Context, clientConn, writerConn net.Co
 	}
 }
 
+// acquireWriterConn returns the bound transaction connection or acquires a new one from the pool.
+// The bool return indicates whether the connection was newly acquired (true) or was already bound (false).
+func (s *Server) acquireWriterConn(ctx context.Context, bound *pool.Conn) (*pool.Conn, bool, error) {
+	if bound != nil {
+		return bound, false, nil
+	}
+	acquireStart := time.Now()
+	conn, err := s.writerPool.Acquire(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("acquire writer: %w", err)
+	}
+	if s.metrics != nil {
+		s.metrics.PoolAcquires.WithLabelValues("writer", s.writerAddr).Inc()
+		s.metrics.PoolAcquireDur.WithLabelValues("writer", s.writerAddr).Observe(time.Since(acquireStart).Seconds())
+	}
+	return conn, true, nil
+}
+
+// resetAndReleaseWriter sends a reset query (DISCARD ALL) and returns the connection to the pool.
+// If the reset fails, the connection is discarded instead.
+func (s *Server) resetAndReleaseWriter(conn *pool.Conn) {
+	if err := s.resetConn(conn); err != nil {
+		slog.Warn("reset writer conn failed, discarding", "error", err)
+		s.writerPool.Discard(conn)
+		return
+	}
+	s.writerPool.Release(conn)
+}
+
+// resetConn sends the configured reset query (e.g. DISCARD ALL) to clean up session state
+// before returning a connection to the pool.
+func (s *Server) resetConn(conn net.Conn) error {
+	resetQuery := s.cfg.Pool.ResetQuery
+	if resetQuery == "" {
+		return nil
+	}
+	payload := append([]byte(resetQuery), 0)
+	if err := protocol.WriteMessage(conn, protocol.MsgQuery, payload); err != nil {
+		return fmt.Errorf("send reset query: %w", err)
+	}
+	for {
+		msg, err := protocol.ReadMessage(conn)
+		if err != nil {
+			return fmt.Errorf("read reset response: %w", err)
+		}
+		if msg.Type == protocol.MsgErrorResponse {
+			return fmt.Errorf("reset query error")
+		}
+		if msg.Type == protocol.MsgReadyForQuery {
+			return nil
+		}
+	}
+}
+
+// fallbackToWriter acquires a writer connection from the pool and forwards the query.
+func (s *Server) fallbackToWriter(ctx context.Context, clientConn net.Conn, msg *protocol.Message) error {
+	wConn, err := s.writerPool.Acquire(ctx)
+	if err != nil {
+		s.sendError(clientConn, "no available backend connections")
+		return fmt.Errorf("acquire writer for fallback: %w", err)
+	}
+	if s.metrics != nil {
+		s.metrics.PoolAcquires.WithLabelValues("writer", s.writerAddr).Inc()
+	}
+	err = s.forwardAndRelay(clientConn, wConn, msg)
+	s.resetAndReleaseWriter(wConn)
+	return err
+}
+
 // handleWriteQuery forwards a write query to the writer and invalidates cache.
-func (s *Server) handleWriteQuery(clientConn, writerConn net.Conn, msg *protocol.Message, query string) {
+func (s *Server) handleWriteQuery(clientConn net.Conn, writerConn net.Conn, msg *protocol.Message, query string) {
 	if err := s.forwardAndRelay(clientConn, writerConn, msg); err != nil {
 		slog.Error("forward write to writer", "error", err)
 		return
@@ -434,7 +620,7 @@ func (s *Server) handleWriteQuery(clientConn, writerConn net.Conn, msg *protocol
 }
 
 // handleReadQuery checks cache, acquires a reader from pool, or falls back to writer.
-func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net.Conn, msg *protocol.Message, query string) error {
+func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string) error {
 	// Check cache
 	if s.queryCache != nil {
 		key := cache.CacheKey(query)
@@ -458,7 +644,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.forwardAndRelay(clientConn, writerConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
 
 	rPool, ok := s.readerPools[readerAddr]
@@ -467,7 +653,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.forwardAndRelay(clientConn, writerConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
 
 	acquireStart := time.Now()
@@ -477,7 +663,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.forwardAndRelay(clientConn, writerConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
 	if s.metrics != nil {
 		s.metrics.PoolAcquires.WithLabelValues("reader", readerAddr).Inc()
@@ -489,7 +675,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net
 		slog.Error("forward to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
 		// Fallback to writer
-		return s.forwardAndRelay(clientConn, writerConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
 
 	// Relay response and collect bytes for caching
@@ -519,21 +705,27 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn, writerConn net
 }
 
 // handleExtendedRead sends buffered Extended Query messages to a reader, falling back to writer.
-func (s *Server) handleExtendedRead(ctx context.Context, clientConn, writerConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string) error {
-	// Fallback helper: send entire batch to writer
+func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string) error {
+	// Fallback helper: send entire batch to writer via pool
 	fallbackToWriter := func() error {
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		for _, m := range buf {
-			if err := protocol.WriteMessage(writerConn, m.Type, m.Payload); err != nil {
-				return fmt.Errorf("forward ext to writer: %w", err)
-			}
+		wConn, err := s.writerPool.Acquire(ctx)
+		if err != nil {
+			s.sendError(clientConn, "no available backend connections")
+			return fmt.Errorf("acquire writer for ext fallback: %w", err)
 		}
-		if err := protocol.WriteMessage(writerConn, syncMsg.Type, syncMsg.Payload); err != nil {
-			return fmt.Errorf("forward sync to writer: %w", err)
+		if err := s.forwardExtBatch(wConn, buf, syncMsg); err != nil {
+			s.writerPool.Discard(wConn)
+			return fmt.Errorf("forward ext to writer: %w", err)
 		}
-		return s.relayUntilReady(clientConn, writerConn)
+		if err := s.relayUntilReady(clientConn, wConn); err != nil {
+			s.writerPool.Discard(wConn)
+			return err
+		}
+		s.resetAndReleaseWriter(wConn)
+		return nil
 	}
 
 	if readerAddr == "" {
@@ -559,15 +751,8 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn, writerConn 
 	}
 
 	// Forward all buffered messages + Sync to reader
-	for _, m := range buf {
-		if err := protocol.WriteMessage(rConn, m.Type, m.Payload); err != nil {
-			slog.Error("forward ext to reader", "addr", readerAddr, "error", err)
-			rPool.Discard(rConn)
-			return fallbackToWriter()
-		}
-	}
-	if err := protocol.WriteMessage(rConn, syncMsg.Type, syncMsg.Payload); err != nil {
-		slog.Error("forward sync to reader", "addr", readerAddr, "error", err)
+	if err := s.forwardExtBatch(rConn, buf, syncMsg); err != nil {
+		slog.Error("forward ext to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
 		return fallbackToWriter()
 	}
@@ -596,6 +781,19 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn, writerConn 
 		rPool.Release(rConn)
 	}
 
+	return nil
+}
+
+// forwardExtBatch sends a batch of Extended Query messages followed by a Sync message.
+func (s *Server) forwardExtBatch(backendConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message) error {
+	for _, m := range buf {
+		if err := protocol.WriteMessage(backendConn, m.Type, m.Payload); err != nil {
+			return fmt.Errorf("forward ext message: %w", err)
+		}
+	}
+	if err := protocol.WriteMessage(backendConn, syncMsg.Type, syncMsg.Payload); err != nil {
+		return fmt.Errorf("forward sync: %w", err)
+	}
 	return nil
 }
 
@@ -692,12 +890,21 @@ func (s *Server) ReaderPools() map[string]*pool.Pool {
 	return s.readerPools
 }
 
+// WriterPool returns the server's writer connection pool.
+func (s *Server) WriterPool() *pool.Pool {
+	return s.writerPool
+}
+
 // Invalidator returns the server's cache invalidator (may be nil).
 func (s *Server) Invalidator() *cache.Invalidator {
 	return s.invalidator
 }
 
-func (s *Server) closeReaderPools() {
+func (s *Server) closePools() {
+	if s.writerPool != nil {
+		s.writerPool.Close()
+		slog.Debug("writer pool closed", "addr", s.writerAddr)
+	}
 	for addr, p := range s.readerPools {
 		p.Close()
 		slog.Debug("reader pool closed", "addr", addr)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -136,6 +136,15 @@ func (s *Session) InTransaction() bool {
 	return s.inTransaction
 }
 
+// SetInTransaction explicitly sets the transaction state.
+// Used by the Extended Query path where transaction control (BEGIN/COMMIT)
+// comes via Parse messages rather than Simple Query.
+func (s *Session) SetInTransaction(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inTransaction = v
+}
+
 // RegisterStatement records the route for a prepared statement.
 // The unnamed statement ("") is also tracked and overwritten on each Parse.
 func (s *Session) RegisterStatement(name, query string) Route {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,6 +125,331 @@ func TestE2E_ProxyIntegration(t *testing.T) {
 			t.Errorf("cache inconsistency: %q != %q", name1, name2)
 		}
 		t.Logf("Cache test OK: %s", name1)
+	})
+}
+
+// TestE2E_TransactionPooling tests transaction-level connection pooling behavior.
+// Requires: docker-compose up && go run ./cmd/db-proxy config.test.yaml
+func TestE2E_TransactionPooling(t *testing.T) {
+	proxyDSN := "postgres://postgres:postgres@127.0.0.1:15440/testdb?sslmode=disable"
+
+	db, err := sql.Open("postgres", proxyDSN)
+	if err != nil {
+		t.Skipf("cannot open proxy connection: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Skipf("proxy not reachable (start docker-compose + proxy first): %v", err)
+	}
+
+	// Create a temp table for pooling tests
+	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS pooling_test (
+		id SERIAL PRIMARY KEY,
+		client_id INT NOT NULL,
+		value TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create pooling_test table: %v", err)
+	}
+	defer db.ExecContext(ctx, "DROP TABLE IF EXISTS pooling_test")
+
+	t.Run("ConcurrentWriters", func(t *testing.T) {
+		// Multiple concurrent clients writing through the pool.
+		// config.test.yaml has max_connections=10, so 20 concurrent writers
+		// must share those 10 connections via pooling.
+		const numClients = 20
+		var wg sync.WaitGroup
+		var successCount atomic.Int32
+
+		for i := 0; i < numClients; i++ {
+			wg.Add(1)
+			go func(clientID int) {
+				defer wg.Done()
+
+				conn, err := sql.Open("postgres", proxyDSN)
+				if err != nil {
+					t.Logf("client %d: open failed: %v", clientID, err)
+					return
+				}
+				defer conn.Close()
+
+				_, err = conn.ExecContext(ctx,
+					"INSERT INTO pooling_test (client_id, value) VALUES ($1, $2)",
+					clientID, fmt.Sprintf("data-%d", clientID))
+				if err != nil {
+					t.Logf("client %d: INSERT failed: %v", clientID, err)
+					return
+				}
+				successCount.Add(1)
+			}(i)
+		}
+
+		wg.Wait()
+
+		if got := successCount.Load(); got != numClients {
+			t.Errorf("successful inserts = %d, want %d", got, numClients)
+		}
+
+		// Verify all rows exist
+		var count int
+		err := db.QueryRowContext(ctx, "SELECT count(*) FROM pooling_test").Scan(&count)
+		if err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		if count != numClients {
+			t.Errorf("row count = %d, want %d", count, numClients)
+		}
+		t.Logf("Concurrent writers OK: %d/%d succeeded", successCount.Load(), numClients)
+
+		// Clean up
+		db.ExecContext(ctx, "DELETE FROM pooling_test")
+	})
+
+	t.Run("TransactionIsolation", func(t *testing.T) {
+		// Verify that a transaction sees its own writes consistently,
+		// meaning all queries within BEGIN..COMMIT go to the same backend connection.
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BEGIN: %v", err)
+		}
+
+		_, err = tx.ExecContext(ctx, "INSERT INTO pooling_test (client_id, value) VALUES (999, 'tx-isolation')")
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("INSERT in tx: %v", err)
+		}
+
+		// SELECT within the same transaction must see the uncommitted row
+		var value string
+		err = tx.QueryRowContext(ctx, "SELECT value FROM pooling_test WHERE client_id = 999").Scan(&value)
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("SELECT in tx: %v", err)
+		}
+		if value != "tx-isolation" {
+			tx.Rollback()
+			t.Errorf("value = %q, want 'tx-isolation'", value)
+		}
+
+		// Another connection outside the transaction should NOT see this row
+		var outsideCount int
+		// Use a fresh connection to avoid being on the same backend
+		outsideConn, _ := sql.Open("postgres", proxyDSN)
+		defer outsideConn.Close()
+		err = outsideConn.QueryRowContext(ctx, "SELECT count(*) FROM pooling_test WHERE client_id = 999").Scan(&outsideCount)
+		if err != nil {
+			tx.Rollback()
+			t.Fatalf("outside SELECT: %v", err)
+		}
+		if outsideCount != 0 {
+			t.Errorf("outside tx saw %d uncommitted rows, want 0", outsideCount)
+		}
+
+		tx.Rollback()
+		t.Log("Transaction isolation OK: uncommitted data not visible outside tx")
+	})
+
+	t.Run("SessionResetAfterRelease", func(t *testing.T) {
+		// Verify that DISCARD ALL resets session state between users.
+		// Client A sets a session variable, then disconnects (connection returns to pool).
+		// Client B acquires a connection and should NOT see A's session state.
+
+		connA, err := sql.Open("postgres", proxyDSN)
+		if err != nil {
+			t.Fatalf("open connA: %v", err)
+		}
+		// Force a single underlying connection so we control the pool conn
+		connA.SetMaxOpenConns(1)
+
+		// Set a session-level parameter
+		_, err = connA.ExecContext(ctx, "SET application_name = 'client_a_session'")
+		if err != nil {
+			connA.Close()
+			t.Fatalf("SET application_name: %v", err)
+		}
+
+		// Verify it was set
+		var appName string
+		err = connA.QueryRowContext(ctx, "SHOW application_name").Scan(&appName)
+		if err != nil {
+			connA.Close()
+			t.Fatalf("SHOW application_name: %v", err)
+		}
+		if appName != "client_a_session" {
+			connA.Close()
+			t.Fatalf("application_name = %q, want 'client_a_session'", appName)
+		}
+
+		// Close client A — connection returns to pool with DISCARD ALL
+		connA.Close()
+
+		// Small delay to ensure connection is returned
+		time.Sleep(100 * time.Millisecond)
+
+		// Client B opens a new connection — should get a reset connection
+		connB, err := sql.Open("postgres", proxyDSN)
+		if err != nil {
+			t.Fatalf("open connB: %v", err)
+		}
+		defer connB.Close()
+		connB.SetMaxOpenConns(1)
+
+		var appNameB string
+		err = connB.QueryRowContext(ctx, "SHOW application_name").Scan(&appNameB)
+		if err != nil {
+			t.Fatalf("SHOW application_name on B: %v", err)
+		}
+
+		// After DISCARD ALL, application_name should be reset to default (empty or "")
+		if appNameB == "client_a_session" {
+			t.Error("session state leaked: client B saw client A's application_name")
+		}
+		t.Logf("Session reset OK: client B got application_name=%q (not 'client_a_session')", appNameB)
+	})
+
+	t.Run("ConcurrentTransactions", func(t *testing.T) {
+		// Multiple concurrent transactions, each doing BEGIN → INSERT → SELECT → COMMIT.
+		// All must succeed and see their own data within the transaction.
+		const numTx = 10
+		var wg sync.WaitGroup
+		var successCount atomic.Int32
+
+		for i := 0; i < numTx; i++ {
+			wg.Add(1)
+			go func(txID int) {
+				defer wg.Done()
+
+				conn, err := sql.Open("postgres", proxyDSN)
+				if err != nil {
+					t.Logf("tx %d: open failed: %v", txID, err)
+					return
+				}
+				defer conn.Close()
+
+				tx, err := conn.BeginTx(ctx, nil)
+				if err != nil {
+					t.Logf("tx %d: BEGIN failed: %v", txID, err)
+					return
+				}
+
+				val := fmt.Sprintf("concurrent-tx-%d", txID)
+				_, err = tx.ExecContext(ctx,
+					"INSERT INTO pooling_test (client_id, value) VALUES ($1, $2)",
+					txID+1000, val)
+				if err != nil {
+					tx.Rollback()
+					t.Logf("tx %d: INSERT failed: %v", txID, err)
+					return
+				}
+
+				// Read back within same transaction
+				var readVal string
+				err = tx.QueryRowContext(ctx,
+					"SELECT value FROM pooling_test WHERE client_id = $1",
+					txID+1000).Scan(&readVal)
+				if err != nil {
+					tx.Rollback()
+					t.Logf("tx %d: SELECT failed: %v", txID, err)
+					return
+				}
+
+				if readVal != val {
+					tx.Rollback()
+					t.Logf("tx %d: value mismatch: got %q, want %q", txID, readVal, val)
+					return
+				}
+
+				if err := tx.Commit(); err != nil {
+					t.Logf("tx %d: COMMIT failed: %v", txID, err)
+					return
+				}
+				successCount.Add(1)
+			}(i)
+		}
+
+		wg.Wait()
+
+		if got := successCount.Load(); got != numTx {
+			t.Errorf("successful transactions = %d, want %d", got, numTx)
+		}
+
+		// Verify all committed rows exist
+		var count int
+		err := db.QueryRowContext(ctx, "SELECT count(*) FROM pooling_test WHERE client_id >= 1000").Scan(&count)
+		if err != nil {
+			t.Fatalf("count committed rows: %v", err)
+		}
+		if count != numTx {
+			t.Errorf("committed row count = %d, want %d", count, numTx)
+		}
+		t.Logf("Concurrent transactions OK: %d/%d succeeded, %d rows committed", successCount.Load(), numTx, count)
+
+		// Clean up
+		db.ExecContext(ctx, "DELETE FROM pooling_test")
+	})
+
+	t.Run("PoolExhaustionAndRecovery", func(t *testing.T) {
+		// Hold all pool connections in transactions, then verify that
+		// new clients eventually succeed after transactions commit.
+		const poolMax = 10 // matches config.test.yaml max_connections
+
+		holders := make([]*sql.Tx, 0, poolMax)
+		holderConns := make([]*sql.DB, 0, poolMax)
+
+		// Acquire all connections by starting transactions
+		for i := 0; i < poolMax; i++ {
+			conn, err := sql.Open("postgres", proxyDSN)
+			if err != nil {
+				t.Fatalf("open holder %d: %v", i, err)
+			}
+			conn.SetMaxOpenConns(1)
+			holderConns = append(holderConns, conn)
+
+			tx, err := conn.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("BEGIN holder %d: %v", i, err)
+			}
+			// Execute a query to ensure connection is actually acquired from pool
+			_, err = tx.ExecContext(ctx, "SELECT 1")
+			if err != nil {
+				tx.Rollback()
+				t.Fatalf("holder %d SELECT: %v", i, err)
+			}
+			holders = append(holders, tx)
+		}
+
+		// Release half the connections
+		for i := 0; i < poolMax/2; i++ {
+			holders[i].Commit()
+			holderConns[i].Close()
+		}
+
+		// Now a new client should be able to acquire a connection
+		newConn, err := sql.Open("postgres", proxyDSN)
+		if err != nil {
+			t.Fatalf("open new client: %v", err)
+		}
+		defer newConn.Close()
+
+		_, err = newConn.ExecContext(ctx, "INSERT INTO pooling_test (client_id, value) VALUES (9999, 'recovery')")
+		if err != nil {
+			t.Errorf("new client INSERT after pool recovery failed: %v", err)
+		} else {
+			t.Log("Pool exhaustion recovery OK: new client succeeded after transactions committed")
+		}
+
+		// Release remaining holders
+		for i := poolMax / 2; i < len(holders); i++ {
+			holders[i].Commit()
+			holderConns[i].Close()
+		}
+
+		// Clean up
+		db.ExecContext(ctx, "DELETE FROM pooling_test")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Writer 커넥션을 풀에서 관리하여 트랜잭션 레벨 Connection Multiplexing 구현
- 클라이언트 인증은 임시 커넥션으로 분리, 풀 커넥션은 `pgConnect()`로 사전 인증
- BEGIN~COMMIT/ROLLBACK 동안 커넥션 바인딩, 반환 시 `DISCARD ALL`로 세션 리셋
- Simple/Extended Query 모두 트랜잭션 풀링 적용

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `internal/proxy/server.go` | 핵심 트랜잭션 풀링 로직 (acquireWriterConn, resetAndReleaseWriter, relayQueries 재작성) |
| `internal/router/router.go` | `SetInTransaction()` 메서드 추가 |
| `internal/config/config.go` | `ResetQuery` 설정 필드 + 기본값 |
| `internal/admin/admin.go` | Writer 풀 통계 노출 |
| `cmd/db-proxy/main.go` | `WriterPool()` 전달 |
| `tests/e2e_test.go` | Transaction Pooling E2E 테스트 5개 |
| `docs/spec.md` | `reset_query` 설정 예시 추가 |

## Test plan
- [x] `go vet ./...` 통과
- [x] 기존 단위 테스트 통과 (`admin_test.go` 시그니처 수정)
- [x] E2E 테스트 작성 (ConcurrentWriters, TransactionIsolation, SessionReset, ConcurrentTransactions, PoolExhaustion)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)