### PR TITLE
feat(proxy): TLS Termination 구현

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -141,6 +141,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		Pool    config.PoolConfig    `json:"pool"`
 		Routing config.RoutingConfig `json:"routing"`
 		Cache   config.CacheConfig   `json:"cache"`
+		TLS     config.TLSConfig     `json:"tls"`
 		Backend struct {
 			User     string `json:"user"`
 			Password string `json:"password"`
@@ -153,6 +154,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		Pool:    s.cfg.Pool,
 		Routing: s.cfg.Routing,
 		Cache:   s.cfg.Cache,
+		TLS:     s.cfg.TLS,
 	}
 	safe.Backend.User = s.cfg.Backend.User
 	safe.Backend.Password = "********"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Backend BackendConfig `yaml:"backend"`
 	Metrics MetricsConfig `yaml:"metrics"`
 	Admin   AdminConfig   `yaml:"admin"`
+	TLS     TLSConfig     `yaml:"tls"`
 }
 
 type MetricsConfig struct {
@@ -28,6 +29,12 @@ type MetricsConfig struct {
 type AdminConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Listen  string `yaml:"listen"`
+}
+
+type TLSConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	CertFile string `yaml:"cert_file"`
+	KeyFile  string `yaml:"key_file"`
 }
 
 type BackendConfig struct {
@@ -162,6 +169,20 @@ func (c *Config) validate() error {
 		}
 		if r.Port <= 0 || r.Port > 65535 {
 			return fmt.Errorf("readers[%d].port must be between 1 and 65535, got %d", i, r.Port)
+		}
+	}
+	if c.TLS.Enabled {
+		if c.TLS.CertFile == "" {
+			return fmt.Errorf("tls.cert_file is required when tls is enabled")
+		}
+		if c.TLS.KeyFile == "" {
+			return fmt.Errorf("tls.key_file is required when tls is enabled")
+		}
+		if _, err := os.Stat(c.TLS.CertFile); err != nil {
+			return fmt.Errorf("tls.cert_file: %w", err)
+		}
+		if _, err := os.Stat(c.TLS.KeyFile); err != nil {
+			return fmt.Errorf("tls.key_file: %w", err)
 		}
 	}
 	if c.Pool.MinConnections < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -217,6 +217,76 @@ readers:
 	}
 }
 
+func TestLoad_TLS_Disabled(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+`
+	cfg := loadFromString(t, content)
+	if cfg.TLS.Enabled {
+		t.Error("TLS.Enabled should be false by default")
+	}
+}
+
+func TestLoad_TLS_MissingCertFile(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+tls:
+  enabled: true
+  key_file: "/tmp/nonexistent.key"
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for missing cert_file")
+	}
+}
+
+func TestLoad_TLS_MissingKeyFile(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+tls:
+  enabled: true
+  cert_file: "/tmp/nonexistent.crt"
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for missing key_file")
+	}
+}
+
+func TestLoad_TLS_FileNotFound(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+tls:
+  enabled: true
+  cert_file: "/tmp/nonexistent.crt"
+  key_file: "/tmp/nonexistent.key"
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for nonexistent TLS files")
+	}
+}
+
 func loadFromString(t *testing.T, content string) *Config {
 	t.Helper()
 	cfg, err := loadFromStringRaw(t, content)

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
@@ -30,6 +31,7 @@ type Server struct {
 	invalidator *cache.Invalidator
 	metrics     *metrics.Metrics
 	listener    net.Listener
+	tlsConfig   *tls.Config
 	wg          sync.WaitGroup
 }
 
@@ -124,10 +126,24 @@ func NewServer(cfg *config.Config) *Server {
 		slog.Info("reader pool created", "addr", addr, "max_conn", cfg.Pool.MaxConnections)
 	}
 
+	// Load TLS certificate if enabled
+	if cfg.TLS.Enabled {
+		cert, err := tls.LoadX509KeyPair(cfg.TLS.CertFile, cfg.TLS.KeyFile)
+		if err != nil {
+			slog.Error("load TLS certificate", "error", err)
+		} else {
+			s.tlsConfig = &tls.Config{
+				Certificates: []tls.Certificate{cert},
+			}
+			slog.Info("TLS enabled", "cert", cfg.TLS.CertFile)
+		}
+	}
+
 	slog.Info("server initialized",
 		"writer", writerAddr,
 		"readers", len(readerAddrs),
 		"cache", cfg.Cache.Enabled,
+		"tls", cfg.TLS.Enabled,
 		"pooling", "transaction")
 
 	return s
@@ -192,8 +208,9 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 }
 
-func (s *Server) handleConn(ctx context.Context, clientConn net.Conn) {
-	defer clientConn.Close()
+func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
+	defer rawConn.Close()
+	clientConn := rawConn // may be upgraded to TLS below
 	slog.Info("new connection", "remote", clientConn.RemoteAddr())
 
 	// 1. Read startup message from client
@@ -203,17 +220,33 @@ func (s *Server) handleConn(ctx context.Context, clientConn net.Conn) {
 		return
 	}
 
-	// 2. Handle SSL request — reject and wait for real startup
+	// 2. Handle SSL request
 	if len(startup.Payload) >= 4 {
 		code := binary.BigEndian.Uint32(startup.Payload[0:4])
 		if code == protocol.SSLRequestCode {
-			if _, err := clientConn.Write([]byte{'N'}); err != nil {
-				slog.Error("write ssl reject", "error", err)
-				return
+			if s.tlsConfig != nil {
+				// Accept TLS — respond 'S' and upgrade connection
+				if _, err := clientConn.Write([]byte{'S'}); err != nil {
+					slog.Error("write ssl accept", "error", err)
+					return
+				}
+				tlsConn := tls.Server(clientConn, s.tlsConfig)
+				if err := tlsConn.Handshake(); err != nil {
+					slog.Error("TLS handshake", "error", err)
+					return
+				}
+				clientConn = tlsConn
+				slog.Debug("TLS connection established", "remote", clientConn.RemoteAddr())
+			} else {
+				// No TLS configured — reject
+				if _, err := clientConn.Write([]byte{'N'}); err != nil {
+					slog.Error("write ssl reject", "error", err)
+					return
+				}
 			}
 			startup, err = protocol.ReadStartupMessage(clientConn)
 			if err != nil {
-				slog.Error("read startup after ssl reject", "error", err)
+				slog.Error("read startup after ssl", "error", err)
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
- 프록시에서 TLS 종단하여 클라이언트-프록시 구간 암호화 지원
- SSL 요청 시 `'S'` 응답 후 `tls.Server()`로 커넥션 업그레이드
- TLS 미설정 시 기존 동작 유지 (`'N'` 거부)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `internal/config/config.go` | `TLSConfig` 구조체 + validation |
| `internal/config/config_test.go` | TLS 설정 테스트 4건 |
| `internal/proxy/server.go` | TLS 핸드셰이크 + 커넥션 업그레이드 |
| `internal/admin/admin.go` | `/admin/config`에 TLS 상태 노출 |

## 설정 예시
```yaml
tls:
  enabled: true
  cert_file: "/path/to/server.crt"
  key_file: "/path/to/server.key"
```

## Test plan
- [x] `go vet ./...` 통과
- [x] TLS 설정 단위 테스트 4건 통과
- [x] 기존 테스트 영향 없음

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)