### PR TITLE
feat(proxy): 프록시 자체 인증 (Front-end Auth)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -133,7 +133,11 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create a safe copy with masked password
+	// Create a safe copy with masked passwords
+	type safeAuthUser struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
 	safe := struct {
 		Proxy   config.ProxyConfig   `json:"proxy"`
 		Writer  config.DBConfig      `json:"writer"`
@@ -142,6 +146,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		Routing config.RoutingConfig `json:"routing"`
 		Cache   config.CacheConfig   `json:"cache"`
 		TLS     config.TLSConfig     `json:"tls"`
+		Auth    struct {
+			Enabled bool           `json:"enabled"`
+			Users   []safeAuthUser `json:"users,omitempty"`
+		} `json:"auth"`
 		Backend struct {
 			User     string `json:"user"`
 			Password string `json:"password"`
@@ -155,6 +163,13 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		Routing: s.cfg.Routing,
 		Cache:   s.cfg.Cache,
 		TLS:     s.cfg.TLS,
+	}
+	safe.Auth.Enabled = s.cfg.Auth.Enabled
+	for _, u := range s.cfg.Auth.Users {
+		safe.Auth.Users = append(safe.Auth.Users, safeAuthUser{
+			Username: u.Username,
+			Password: "********",
+		})
 	}
 	safe.Backend.User = s.cfg.Backend.User
 	safe.Backend.Password = "********"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Metrics MetricsConfig `yaml:"metrics"`
 	Admin   AdminConfig   `yaml:"admin"`
 	TLS     TLSConfig     `yaml:"tls"`
+	Auth    AuthConfig    `yaml:"auth"`
 }
 
 type MetricsConfig struct {
@@ -35,6 +36,16 @@ type TLSConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	CertFile string `yaml:"cert_file"`
 	KeyFile  string `yaml:"key_file"`
+}
+
+type AuthConfig struct {
+	Enabled bool       `yaml:"enabled"`
+	Users   []AuthUser `yaml:"users"`
+}
+
+type AuthUser struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 type BackendConfig struct {
@@ -184,6 +195,9 @@ func (c *Config) validate() error {
 		if _, err := os.Stat(c.TLS.KeyFile); err != nil {
 			return fmt.Errorf("tls.key_file: %w", err)
 		}
+	}
+	if c.Auth.Enabled && len(c.Auth.Users) == 0 {
+		return fmt.Errorf("auth.users is required when auth is enabled")
 	}
 	if c.Pool.MinConnections < 0 {
 		return fmt.Errorf("pool.min_connections must be >= 0, got %d", c.Pool.MinConnections)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -217,6 +217,66 @@ readers:
 	}
 }
 
+func TestLoad_Auth_Disabled(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+`
+	cfg := loadFromString(t, content)
+	if cfg.Auth.Enabled {
+		t.Error("Auth.Enabled should be false by default")
+	}
+}
+
+func TestLoad_Auth_Enabled(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+auth:
+  enabled: true
+  users:
+    - username: "app_user"
+      password: "secret"
+    - username: "readonly"
+      password: "readonly_pass"
+`
+	cfg := loadFromString(t, content)
+	if !cfg.Auth.Enabled {
+		t.Error("Auth.Enabled should be true")
+	}
+	if len(cfg.Auth.Users) != 2 {
+		t.Fatalf("len(Auth.Users) = %d, want 2", len(cfg.Auth.Users))
+	}
+	if cfg.Auth.Users[0].Username != "app_user" {
+		t.Errorf("Auth.Users[0].Username = %q, want app_user", cfg.Auth.Users[0].Username)
+	}
+}
+
+func TestLoad_Auth_EnabledNoUsers(t *testing.T) {
+	content := `
+writer:
+  host: "primary.db.internal"
+  port: 5432
+readers:
+  - host: "replica-1.db.internal"
+    port: 5432
+auth:
+  enabled: true
+`
+	_, err := loadFromStringRaw(t, content)
+	if err == nil {
+		t.Error("expected error for auth.enabled with no users")
+	}
+}
+
 func TestLoad_TLS_Disabled(t *testing.T) {
 	content := `
 writer:

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -255,38 +256,41 @@ func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
 	_, _, params := protocol.ParseStartupParams(startup.Payload)
 	slog.Info("client startup", "user", params["user"], "database", params["database"])
 
-	// 3. Authenticate client via temporary backend connection.
-	//    Pool connections are pre-authenticated via pgConnect(), so we only need
-	//    a temporary connection to relay the client's auth handshake.
-	authConn, err := net.Dial("tcp", s.writerAddr)
-	if err != nil {
-		slog.Error("connect to writer for auth", "addr", s.writerAddr, "error", err)
-		s.sendError(clientConn, "cannot connect to backend database")
-		return
-	}
+	// 3. Authenticate client
+	if s.cfg.Auth.Enabled {
+		// Front-end auth: proxy authenticates the client directly using MD5.
+		if err := s.frontendAuth(clientConn, params["user"]); err != nil {
+			slog.Warn("frontend auth failed", "user", params["user"], "remote", rawConn.RemoteAddr(), "error", err)
+			return
+		}
+		slog.Info("frontend auth success", "user", params["user"], "remote", rawConn.RemoteAddr())
+	} else {
+		// Backend auth relay: temporary connection to relay the client's auth handshake.
+		authConn, err := net.Dial("tcp", s.writerAddr)
+		if err != nil {
+			slog.Error("connect to writer for auth", "addr", s.writerAddr, "error", err)
+			s.sendError(clientConn, "cannot connect to backend database")
+			return
+		}
 
-	// Forward startup message to auth connection
-	startupRaw := make([]byte, 4+len(startup.Payload))
-	binary.BigEndian.PutUint32(startupRaw[0:4], uint32(4+len(startup.Payload)))
-	copy(startupRaw[4:], startup.Payload)
-	if err := protocol.WriteRaw(authConn, startupRaw); err != nil {
+		startupRaw := make([]byte, 4+len(startup.Payload))
+		binary.BigEndian.PutUint32(startupRaw[0:4], uint32(4+len(startup.Payload)))
+		copy(startupRaw[4:], startup.Payload)
+		if err := protocol.WriteRaw(authConn, startupRaw); err != nil {
+			authConn.Close()
+			slog.Error("forward startup to writer", "error", err)
+			return
+		}
+
+		if err := s.relayAuth(clientConn, authConn); err != nil {
+			authConn.Close()
+			slog.Error("auth relay", "error", err)
+			return
+		}
 		authConn.Close()
-		slog.Error("forward startup to writer", "error", err)
-		return
 	}
 
-	// Relay authentication between client and auth connection
-	if err := s.relayAuth(clientConn, authConn); err != nil {
-		authConn.Close()
-		slog.Error("auth relay", "error", err)
-		return
-	}
-
-	// Auth complete — close temporary connection.
-	// All further queries use pooled connections.
-	authConn.Close()
-
-	slog.Info("handshake complete", "remote", clientConn.RemoteAddr())
+	slog.Info("handshake complete", "remote", rawConn.RemoteAddr())
 
 	// 4. Create per-client session router
 	session := router.NewSession(s.cfg.Routing.ReadAfterWriteDelay)
@@ -330,6 +334,70 @@ func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
 			}
 		}
 	}
+}
+
+// frontendAuth authenticates the client directly at the proxy using MD5 auth.
+// If the user is not in the configured auth.users list, returns an error.
+func (s *Server) frontendAuth(clientConn net.Conn, username string) error {
+	// Look up user in config
+	var password string
+	found := false
+	for _, u := range s.cfg.Auth.Users {
+		if u.Username == username {
+			password = u.Password
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		s.sendError(clientConn, fmt.Sprintf("user \"%s\" is not allowed to connect", username))
+		return fmt.Errorf("user %q not in auth.users", username)
+	}
+
+	// Send MD5 auth challenge (AuthenticationMD5Password, type=5)
+	salt := make([]byte, 4)
+	if _, err := rand.Read(salt); err != nil {
+		return fmt.Errorf("generate salt: %w", err)
+	}
+	authPayload := make([]byte, 8)
+	binary.BigEndian.PutUint32(authPayload[0:4], 5) // MD5Password
+	copy(authPayload[4:8], salt)
+	if err := protocol.WriteMessage(clientConn, protocol.MsgAuthentication, authPayload); err != nil {
+		return fmt.Errorf("send MD5 challenge: %w", err)
+	}
+
+	// Read client's password response ('p')
+	msg, err := protocol.ReadMessage(clientConn)
+	if err != nil {
+		return fmt.Errorf("read password response: %w", err)
+	}
+	if msg.Type != 'p' {
+		return fmt.Errorf("expected password message, got %c", msg.Type)
+	}
+
+	// Client sends: "md5" + md5(md5(password + user) + salt) + \0
+	clientHash := strings.TrimRight(string(msg.Payload), "\x00")
+	expectedHash := pgMD5Password(username, password, salt)
+
+	if clientHash != expectedHash {
+		s.sendError(clientConn, "password authentication failed for user \""+username+"\"")
+		return fmt.Errorf("MD5 password mismatch for user %q", username)
+	}
+
+	// Send AuthenticationOk (type=0)
+	okPayload := make([]byte, 4)
+	binary.BigEndian.PutUint32(okPayload[0:4], 0)
+	if err := protocol.WriteMessage(clientConn, protocol.MsgAuthentication, okPayload); err != nil {
+		return fmt.Errorf("send auth ok: %w", err)
+	}
+
+	// Send ReadyForQuery ('Z', status='I' for idle)
+	if err := protocol.WriteMessage(clientConn, protocol.MsgReadyForQuery, []byte{'I'}); err != nil {
+		return fmt.Errorf("send ready for query: %w", err)
+	}
+
+	return nil
 }
 
 // authNeedsResponse returns true if the PG auth type requires a client response.


### PR DESCRIPTION
## Summary
- 프록시 자체 인증으로 불량 접속을 백엔드 도달 전 차단
- MD5 기반 인증 — 설정에 없는 유저는 즉시 거부
- Auth 미설정 시 기존 백엔드 패스스루 인증 유지

## 설정 예시
```yaml
auth:
  enabled: true
  users:
    - username: "app_user"
      password: "secret"
    - username: "readonly"
      password: "readonly_pass"
```

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `internal/config/config.go` | `AuthConfig`, `AuthUser` 구조체 + validation |
| `internal/config/config_test.go` | Auth 설정 테스트 3건 |
| `internal/proxy/server.go` | `frontendAuth()` MD5 인증 구현 |
| `internal/admin/admin.go` | `/admin/config`에 Auth 정보 (비밀번호 마스킹) |

## Test plan
- [x] `go vet ./...` 통과
- [x] Auth 설정 단위 테스트 3건 통과
- [x] Admin config 비밀번호 마스킹 테스트 통과
- [x] 기존 테스트 영향 없음

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)