### PR TITLE
feat(resilience): Circuit Breaker 구현 및 풀 통합

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,9 @@ type Config struct {
 	Backend BackendConfig `yaml:"backend"`
 	Metrics MetricsConfig `yaml:"metrics"`
 	Admin   AdminConfig   `yaml:"admin"`
-	TLS     TLSConfig     `yaml:"tls"`
-	Auth    AuthConfig    `yaml:"auth"`
+	TLS            TLSConfig            `yaml:"tls"`
+	Auth           AuthConfig           `yaml:"auth"`
+	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
 }
 
 type MetricsConfig struct {
@@ -46,6 +47,14 @@ type AuthConfig struct {
 type AuthUser struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+}
+
+type CircuitBreakerConfig struct {
+	Enabled        bool          `yaml:"enabled"`
+	ErrorThreshold float64       `yaml:"error_threshold"` // 0.0-1.0
+	OpenDuration   time.Duration `yaml:"open_duration"`
+	HalfOpenMax    int           `yaml:"half_open_max"`
+	WindowSize     int           `yaml:"window_size"`
 }
 
 type BackendConfig struct {
@@ -161,6 +170,18 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Admin.Listen == "" {
 		c.Admin.Listen = "0.0.0.0:9091"
+	}
+	if c.CircuitBreaker.ErrorThreshold <= 0 {
+		c.CircuitBreaker.ErrorThreshold = 0.5
+	}
+	if c.CircuitBreaker.OpenDuration <= 0 {
+		c.CircuitBreaker.OpenDuration = 10 * time.Second
+	}
+	if c.CircuitBreaker.HalfOpenMax <= 0 {
+		c.CircuitBreaker.HalfOpenMax = 3
+	}
+	if c.CircuitBreaker.WindowSize <= 0 {
+		c.CircuitBreaker.WindowSize = 10
 	}
 }
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -18,22 +18,25 @@ import (
 	"github.com/jyukki97/db-proxy/internal/metrics"
 	"github.com/jyukki97/db-proxy/internal/pool"
 	"github.com/jyukki97/db-proxy/internal/protocol"
+	"github.com/jyukki97/db-proxy/internal/resilience"
 	"github.com/jyukki97/db-proxy/internal/router"
 )
 
 type Server struct {
-	cfg         *config.Config
-	listenAddr  string
-	writerAddr  string
-	writerPool  *pool.Pool
-	readerPools map[string]*pool.Pool
-	balancer    *router.RoundRobin
-	queryCache  *cache.Cache
-	invalidator *cache.Invalidator
-	metrics     *metrics.Metrics
-	listener    net.Listener
-	tlsConfig   *tls.Config
-	wg          sync.WaitGroup
+	cfg          *config.Config
+	listenAddr   string
+	writerAddr   string
+	writerPool   *pool.Pool
+	readerPools  map[string]*pool.Pool
+	balancer     *router.RoundRobin
+	queryCache   *cache.Cache
+	invalidator  *cache.Invalidator
+	metrics      *metrics.Metrics
+	listener     net.Listener
+	tlsConfig    *tls.Config
+	writerCB     *resilience.CircuitBreaker
+	readerCBs    map[string]*resilience.CircuitBreaker
+	wg           sync.WaitGroup
 }
 
 func NewServer(cfg *config.Config) *Server {
@@ -125,6 +128,24 @@ func NewServer(cfg *config.Config) *Server {
 		}
 		s.readerPools[addr] = p
 		slog.Info("reader pool created", "addr", addr, "max_conn", cfg.Pool.MaxConnections)
+	}
+
+	// Initialize Circuit Breakers
+	if cfg.CircuitBreaker.Enabled {
+		cbCfg := resilience.BreakerConfig{
+			ErrorThreshold: cfg.CircuitBreaker.ErrorThreshold,
+			OpenDuration:   cfg.CircuitBreaker.OpenDuration,
+			HalfOpenMax:    cfg.CircuitBreaker.HalfOpenMax,
+			WindowSize:     cfg.CircuitBreaker.WindowSize,
+		}
+		s.writerCB = resilience.NewCircuitBreaker(cbCfg)
+		s.readerCBs = make(map[string]*resilience.CircuitBreaker)
+		for _, addr := range readerAddrs {
+			s.readerCBs[addr] = resilience.NewCircuitBreaker(cbCfg)
+		}
+		slog.Info("circuit breakers enabled",
+			"threshold", cbCfg.ErrorThreshold,
+			"open_duration", cbCfg.OpenDuration)
 	}
 
 	// Load TLS certificate if enabled
@@ -632,9 +653,18 @@ func (s *Server) acquireWriterConn(ctx context.Context, bound *pool.Conn) (*pool
 	if bound != nil {
 		return bound, false, nil
 	}
+	// Circuit breaker check
+	if s.writerCB != nil {
+		if err := s.writerCB.Allow(); err != nil {
+			return nil, false, fmt.Errorf("writer circuit breaker open: %w", err)
+		}
+	}
 	acquireStart := time.Now()
 	conn, err := s.writerPool.Acquire(ctx)
 	if err != nil {
+		if s.writerCB != nil {
+			s.writerCB.RecordFailure()
+		}
 		return nil, false, fmt.Errorf("acquire writer: %w", err)
 	}
 	if s.metrics != nil {
@@ -699,7 +729,13 @@ func (s *Server) fallbackToWriter(ctx context.Context, clientConn net.Conn, msg 
 func (s *Server) handleWriteQuery(clientConn net.Conn, writerConn net.Conn, msg *protocol.Message, query string) {
 	if err := s.forwardAndRelay(clientConn, writerConn, msg); err != nil {
 		slog.Error("forward write to writer", "error", err)
+		if s.writerCB != nil {
+			s.writerCB.RecordFailure()
+		}
 		return
+	}
+	if s.writerCB != nil {
+		s.writerCB.RecordSuccess()
 	}
 
 	// Invalidate cache for affected tables
@@ -748,6 +784,17 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
 
+	// Circuit breaker check for reader
+	if cb, ok := s.readerCBs[readerAddr]; ok {
+		if err := cb.Allow(); err != nil {
+			slog.Warn("reader circuit breaker open, fallback to writer", "addr", readerAddr)
+			if s.metrics != nil {
+				s.metrics.ReaderFallback.Inc()
+			}
+			return s.fallbackToWriter(ctx, clientConn, msg)
+		}
+	}
+
 	rPool, ok := s.readerPools[readerAddr]
 	if !ok {
 		slog.Warn("no pool for reader, fallback to writer", "addr", readerAddr)
@@ -763,6 +810,9 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		slog.Warn("acquire reader failed, fallback to writer", "addr", readerAddr, "error", err)
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
+		}
+		if cb, ok := s.readerCBs[readerAddr]; ok {
+			cb.RecordFailure()
 		}
 		return s.fallbackToWriter(ctx, clientConn, msg)
 	}
@@ -797,11 +847,17 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 	} else {
 		if err := s.relayUntilReady(clientConn, rConn); err != nil {
 			rPool.Discard(rConn)
+			if cb, ok := s.readerCBs[readerAddr]; ok {
+				cb.RecordFailure()
+			}
 			return fmt.Errorf("relay reader response: %w", err)
 		}
 		rPool.Release(rConn)
 	}
 
+	if cb, ok := s.readerCBs[readerAddr]; ok {
+		cb.RecordSuccess()
+	}
 	return nil
 }
 

--- a/internal/resilience/breaker.go
+++ b/internal/resilience/breaker.go
@@ -1,0 +1,162 @@
+package resilience
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// State represents the Circuit Breaker state.
+type State int
+
+const (
+	StateClosed   State = iota // normal operation
+	StateOpen                  // failing — reject all requests
+	StateHalfOpen              // testing — allow limited requests
+)
+
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// BreakerConfig configures the Circuit Breaker.
+type BreakerConfig struct {
+	ErrorThreshold float64       // error rate (0.0-1.0) to trip to Open
+	OpenDuration   time.Duration // how long to stay Open before Half-Open
+	HalfOpenMax    int           // max requests allowed in Half-Open state
+	WindowSize     int           // rolling window size for counting errors
+}
+
+// CircuitBreaker implements the Circuit Breaker pattern.
+type CircuitBreaker struct {
+	cfg BreakerConfig
+	mu  sync.Mutex
+
+	state      State
+	successes  int
+	failures   int
+	total      int
+	openedAt   time.Time
+	halfOpenOK int // successful requests in half-open state
+}
+
+// NewCircuitBreaker creates a new Circuit Breaker.
+func NewCircuitBreaker(cfg BreakerConfig) *CircuitBreaker {
+	if cfg.WindowSize <= 0 {
+		cfg.WindowSize = 10
+	}
+	if cfg.HalfOpenMax <= 0 {
+		cfg.HalfOpenMax = 3
+	}
+	if cfg.OpenDuration <= 0 {
+		cfg.OpenDuration = 10 * time.Second
+	}
+	if cfg.ErrorThreshold <= 0 {
+		cfg.ErrorThreshold = 0.5
+	}
+	return &CircuitBreaker{
+		cfg:   cfg,
+		state: StateClosed,
+	}
+}
+
+// Allow checks if a request is allowed through the circuit breaker.
+// Returns an error if the circuit is open.
+func (cb *CircuitBreaker) Allow() error {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case StateClosed:
+		return nil
+	case StateOpen:
+		if time.Since(cb.openedAt) >= cb.cfg.OpenDuration {
+			cb.state = StateHalfOpen
+			cb.halfOpenOK = 0
+			return nil
+		}
+		return fmt.Errorf("circuit breaker is open")
+	case StateHalfOpen:
+		return nil
+	}
+	return nil
+}
+
+// RecordSuccess records a successful request.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case StateClosed:
+		cb.successes++
+		cb.total++
+		cb.evaluateWindow()
+	case StateHalfOpen:
+		cb.halfOpenOK++
+		if cb.halfOpenOK >= cb.cfg.HalfOpenMax {
+			// Enough successes — close the circuit
+			cb.state = StateClosed
+			cb.resetCounters()
+		}
+	}
+}
+
+// RecordFailure records a failed request.
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case StateClosed:
+		cb.failures++
+		cb.total++
+		cb.evaluateWindow()
+	case StateHalfOpen:
+		// Any failure in half-open → back to open
+		cb.state = StateOpen
+		cb.openedAt = time.Now()
+	}
+}
+
+// State returns the current circuit breaker state.
+func (cb *CircuitBreaker) State() State {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	// Check for automatic transition from Open to HalfOpen
+	if cb.state == StateOpen && time.Since(cb.openedAt) >= cb.cfg.OpenDuration {
+		cb.state = StateHalfOpen
+		cb.halfOpenOK = 0
+	}
+	return cb.state
+}
+
+// evaluateWindow checks the error rate when the window is full.
+// If above threshold → trip to Open. Otherwise → reset window for next cycle.
+func (cb *CircuitBreaker) evaluateWindow() {
+	if cb.total < cb.cfg.WindowSize {
+		return
+	}
+	errorRate := float64(cb.failures) / float64(cb.total)
+	if errorRate >= cb.cfg.ErrorThreshold {
+		cb.state = StateOpen
+		cb.openedAt = time.Now()
+	}
+	cb.resetCounters()
+}
+
+func (cb *CircuitBreaker) resetCounters() {
+	cb.successes = 0
+	cb.failures = 0
+	cb.total = 0
+}

--- a/internal/resilience/breaker_test.go
+++ b/internal/resilience/breaker_test.go
@@ -1,0 +1,149 @@
+package resilience
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_ClosedAllows(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     10,
+		OpenDuration:   time.Second,
+	})
+
+	if err := cb.Allow(); err != nil {
+		t.Errorf("closed breaker should allow: %v", err)
+	}
+}
+
+func TestCircuitBreaker_TripsOnErrors(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     10,
+		OpenDuration:   time.Second,
+	})
+
+	// 6 failures, 4 successes = 60% error rate → should trip
+	for i := 0; i < 6; i++ {
+		cb.Allow()
+		cb.RecordFailure()
+	}
+	for i := 0; i < 4; i++ {
+		cb.Allow()
+		cb.RecordSuccess()
+	}
+
+	if cb.State() != StateOpen {
+		t.Errorf("state = %v, want Open", cb.State())
+	}
+	if err := cb.Allow(); err == nil {
+		t.Error("open breaker should reject")
+	}
+}
+
+func TestCircuitBreaker_TransitionsToHalfOpen(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     4,
+		OpenDuration:   50 * time.Millisecond,
+		HalfOpenMax:    2,
+	})
+
+	// Trip the breaker
+	for i := 0; i < 4; i++ {
+		cb.Allow()
+		cb.RecordFailure()
+	}
+
+	if cb.State() != StateOpen {
+		t.Fatalf("state = %v, want Open", cb.State())
+	}
+
+	// Wait for open duration to expire
+	time.Sleep(60 * time.Millisecond)
+
+	if cb.State() != StateHalfOpen {
+		t.Fatalf("state = %v, want HalfOpen", cb.State())
+	}
+
+	if err := cb.Allow(); err != nil {
+		t.Errorf("half-open should allow: %v", err)
+	}
+}
+
+func TestCircuitBreaker_HalfOpenRecovery(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     4,
+		OpenDuration:   50 * time.Millisecond,
+		HalfOpenMax:    2,
+	})
+
+	// Trip the breaker
+	for i := 0; i < 4; i++ {
+		cb.Allow()
+		cb.RecordFailure()
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Succeed enough times in half-open to close
+	for i := 0; i < 2; i++ {
+		cb.Allow()
+		cb.RecordSuccess()
+	}
+
+	if cb.State() != StateClosed {
+		t.Errorf("state = %v, want Closed after recovery", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenFailureReopens(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     4,
+		OpenDuration:   50 * time.Millisecond,
+		HalfOpenMax:    2,
+	})
+
+	// Trip the breaker
+	for i := 0; i < 4; i++ {
+		cb.Allow()
+		cb.RecordFailure()
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	// One success, then failure in half-open → back to open
+	cb.Allow()
+	cb.RecordSuccess()
+	cb.Allow()
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Errorf("state = %v, want Open after half-open failure", cb.State())
+	}
+}
+
+func TestCircuitBreaker_BelowThresholdStaysClosed(t *testing.T) {
+	cb := NewCircuitBreaker(BreakerConfig{
+		ErrorThreshold: 0.5,
+		WindowSize:     10,
+		OpenDuration:   time.Second,
+	})
+
+	// 4 failures, 6 successes = 40% error rate → below 50% threshold
+	for i := 0; i < 4; i++ {
+		cb.Allow()
+		cb.RecordFailure()
+	}
+	for i := 0; i < 6; i++ {
+		cb.Allow()
+		cb.RecordSuccess()
+	}
+
+	if cb.State() != StateClosed {
+		t.Errorf("state = %v, want Closed (below threshold)", cb.State())
+	}
+}


### PR DESCRIPTION
## Summary
- Circuit Breaker 상태 머신 구현 (Closed → Open → Half-Open)
- Writer/Reader 풀에 적용 — 백엔드 장애 시 불필요한 연결 시도 차단
- 에러율 초과 → Open → 일정 시간 후 Half-Open → 성공 시 Closed 복귀

## 설정 예시
```yaml
circuit_breaker:
  enabled: true
  error_threshold: 0.5
  open_duration: 10s
  half_open_max: 3
  window_size: 10
```

## Test plan
- [x] Circuit Breaker 단위 테스트 6건 통과
- [x] `go vet ./...` 통과
- [x] 기존 테스트 영향 없음

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)