### PR TITLE
feat(resilience): Token Bucket Rate Limiter 구현 및 프록시 통합

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	TLS            TLSConfig            `yaml:"tls"`
 	Auth           AuthConfig           `yaml:"auth"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
+	RateLimit      RateLimitConfig      `yaml:"rate_limit"`
 }
 
 type MetricsConfig struct {
@@ -55,6 +56,12 @@ type CircuitBreakerConfig struct {
 	OpenDuration   time.Duration `yaml:"open_duration"`
 	HalfOpenMax    int           `yaml:"half_open_max"`
 	WindowSize     int           `yaml:"window_size"`
+}
+
+type RateLimitConfig struct {
+	Enabled bool    `yaml:"enabled"`
+	Rate    float64 `yaml:"rate"`  // queries per second
+	Burst   int     `yaml:"burst"` // max burst size
 }
 
 type BackendConfig struct {
@@ -170,6 +177,12 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Admin.Listen == "" {
 		c.Admin.Listen = "0.0.0.0:9091"
+	}
+	if c.RateLimit.Rate <= 0 {
+		c.RateLimit.Rate = 1000
+	}
+	if c.RateLimit.Burst <= 0 {
+		c.RateLimit.Burst = 100
 	}
 	if c.CircuitBreaker.ErrorThreshold <= 0 {
 		c.CircuitBreaker.ErrorThreshold = 0.5

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,6 +17,9 @@ type Metrics struct {
 	CacheEntries       prometheus.Gauge
 	CacheInvalidations prometheus.Counter
 
+	// Rate limiting
+	RateLimited prometheus.Counter
+
 	// Pool
 	PoolOpenConns *prometheus.GaugeVec
 	PoolIdleConns *prometheus.GaugeVec
@@ -74,6 +77,13 @@ func New() *Metrics {
 			},
 		),
 
+		RateLimited: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "dbproxy_rate_limited_total",
+				Help: "Total number of rate-limited requests.",
+			},
+		),
+
 		PoolOpenConns: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "dbproxy_pool_connections_open",
@@ -109,6 +119,7 @@ func New() *Metrics {
 		m.QueriesRouted,
 		m.QueryDuration,
 		m.ReaderFallback,
+		m.RateLimited,
 		m.CacheHits,
 		m.CacheMisses,
 		m.CacheEntries,

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	tlsConfig    *tls.Config
 	writerCB     *resilience.CircuitBreaker
 	readerCBs    map[string]*resilience.CircuitBreaker
+	rateLimiter  *resilience.RateLimiter
 	wg           sync.WaitGroup
 }
 
@@ -128,6 +129,12 @@ func NewServer(cfg *config.Config) *Server {
 		}
 		s.readerPools[addr] = p
 		slog.Info("reader pool created", "addr", addr, "max_conn", cfg.Pool.MaxConnections)
+	}
+
+	// Initialize Rate Limiter
+	if cfg.RateLimit.Enabled {
+		s.rateLimiter = resilience.NewRateLimiter(cfg.RateLimit.Rate, cfg.RateLimit.Burst)
+		slog.Info("rate limiter enabled", "rate", cfg.RateLimit.Rate, "burst", cfg.RateLimit.Burst)
 	}
 
 	// Initialize Circuit Breakers
@@ -471,6 +478,18 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 		if msg.Type == protocol.MsgTerminate {
 			slog.Info("client terminated", "remote", clientConn.RemoteAddr())
 			return
+		}
+
+		// Rate limit check
+		if s.rateLimiter != nil && !s.rateLimiter.Allow() {
+			slog.Warn("rate limited", "remote", clientConn.RemoteAddr())
+			if s.metrics != nil {
+				s.metrics.RateLimited.Inc()
+			}
+			s.sendError(clientConn, "too many requests")
+			// Send ReadyForQuery so the client can continue
+			protocol.WriteMessage(clientConn, protocol.MsgReadyForQuery, []byte{'I'})
+			continue
 		}
 
 		// --- Simple Query Protocol ---

--- a/internal/resilience/ratelimit.go
+++ b/internal/resilience/ratelimit.go
@@ -1,0 +1,48 @@
+package resilience
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter implements a Token Bucket rate limiter.
+type RateLimiter struct {
+	mu       sync.Mutex
+	rate     float64   // tokens per second
+	burst    int       // max tokens (bucket capacity)
+	tokens   float64   // current tokens
+	lastTime time.Time // last refill time
+}
+
+// NewRateLimiter creates a new Token Bucket rate limiter.
+// rate: tokens added per second. burst: maximum tokens (bucket capacity).
+func NewRateLimiter(rate float64, burst int) *RateLimiter {
+	return &RateLimiter{
+		rate:     rate,
+		burst:    burst,
+		tokens:   float64(burst), // start full
+		lastTime: time.Now(),
+	}
+}
+
+// Allow checks if a request is allowed. Returns true if a token is available.
+func (rl *RateLimiter) Allow() bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(rl.lastTime).Seconds()
+	rl.lastTime = now
+
+	// Refill tokens
+	rl.tokens += elapsed * rl.rate
+	if rl.tokens > float64(rl.burst) {
+		rl.tokens = float64(rl.burst)
+	}
+
+	if rl.tokens >= 1.0 {
+		rl.tokens--
+		return true
+	}
+	return false
+}

--- a/internal/resilience/ratelimit_test.go
+++ b/internal/resilience/ratelimit_test.go
@@ -1,0 +1,65 @@
+package resilience
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_AllowsBurst(t *testing.T) {
+	rl := NewRateLimiter(10, 5) // 10/s, burst 5
+
+	// Should allow burst of 5
+	for i := 0; i < 5; i++ {
+		if !rl.Allow() {
+			t.Errorf("request %d should be allowed (within burst)", i)
+		}
+	}
+
+	// 6th should be rejected (burst exhausted)
+	if rl.Allow() {
+		t.Error("6th request should be rejected (burst exhausted)")
+	}
+}
+
+func TestRateLimiter_RefillsOverTime(t *testing.T) {
+	rl := NewRateLimiter(100, 5) // 100/s, burst 5
+
+	// Exhaust all tokens
+	for i := 0; i < 5; i++ {
+		rl.Allow()
+	}
+
+	// Wait for some tokens to refill (100/s = 1 token per 10ms)
+	time.Sleep(30 * time.Millisecond) // should refill ~3 tokens
+
+	allowed := 0
+	for i := 0; i < 5; i++ {
+		if rl.Allow() {
+			allowed++
+		}
+	}
+
+	// Should have refilled at least 1 token (timing can be imprecise)
+	if allowed < 1 {
+		t.Errorf("expected at least 1 allowed after refill, got %d", allowed)
+	}
+}
+
+func TestRateLimiter_SteadyRate(t *testing.T) {
+	rl := NewRateLimiter(1000, 1) // 1000/s, burst 1
+
+	// Exhaust the 1 burst token
+	if !rl.Allow() {
+		t.Error("first request should be allowed")
+	}
+	if rl.Allow() {
+		t.Error("second immediate request should be rejected")
+	}
+
+	// Wait 2ms for ~2 tokens to refill
+	time.Sleep(2 * time.Millisecond)
+
+	if !rl.Allow() {
+		t.Error("request after refill should be allowed")
+	}
+}


### PR DESCRIPTION
## Summary
- Token Bucket 알고리즘 기반 Rate Limiter 구현
- 쿼리 처리 전 rate limit 체크, 초과 시 `too many requests` 에러 반환
- `dbproxy_rate_limited_total` Prometheus 메트릭 추가

## 설정 예시
```yaml
rate_limit:
  enabled: true
  rate: 1000    # queries per second
  burst: 100    # max burst
```

## Test plan
- [x] Rate Limiter 단위 테스트 3건 통과
- [x] `go vet ./...` 통과
- [x] 기존 테스트 영향 없음

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)