### PR TITLE
feat(router): LSN 타입 정의 및 비교 유틸리티

### DIFF
--- a/internal/router/lsn.go
+++ b/internal/router/lsn.go
@@ -1,0 +1,43 @@
+package router
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// LSN represents a PostgreSQL Log Sequence Number as a uint64.
+type LSN uint64
+
+// InvalidLSN is the zero value indicating no LSN has been recorded.
+const InvalidLSN LSN = 0
+
+// ParseLSN parses a PostgreSQL LSN string (e.g. "0/16B3748") into an LSN value.
+func ParseLSN(s string) (LSN, error) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("invalid LSN format: %q", s)
+	}
+
+	hi, err := strconv.ParseUint(parts[0], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid LSN high part: %w", err)
+	}
+
+	lo, err := strconv.ParseUint(parts[1], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid LSN low part: %w", err)
+	}
+
+	return LSN(hi<<32 | lo), nil
+}
+
+// String formats the LSN back to PostgreSQL format (e.g. "0/16B3748").
+func (l LSN) String() string {
+	return fmt.Sprintf("%X/%X", uint32(l>>32), uint32(l))
+}
+
+// IsZero returns true if the LSN is the zero/invalid value.
+func (l LSN) IsZero() bool {
+	return l == InvalidLSN
+}

--- a/internal/router/lsn_test.go
+++ b/internal/router/lsn_test.go
@@ -1,0 +1,106 @@
+package router
+
+import (
+	"testing"
+)
+
+func TestParseLSN(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    LSN
+		wantErr bool
+	}{
+		{"0/16B3748", 0x016B3748, false},
+		{"0/0", 0, false},
+		{"1/0", 0x100000000, false},
+		{"FF/FFFFFFFF", 0xFFFFFFFFFF, false},
+		{"A/B", 0xA0000000B, false},
+		{"0/1", 1, false},
+		// invalid cases
+		{"", 0, true},
+		{"noslash", 0, true},
+		{"0/GGG", 0, true},
+		{"ZZZ/0", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseLSN(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseLSN(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseLSN(%q) = %d (0x%X), want %d (0x%X)", tt.input, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestLSNString(t *testing.T) {
+	tests := []struct {
+		lsn  LSN
+		want string
+	}{
+		{0x016B3748, "0/16B3748"},
+		{0, "0/0"},
+		{0x100000000, "1/0"},
+		{0xFFFFFFFFFF, "FF/FFFFFFFF"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.lsn.String()
+			if got != tt.want {
+				t.Errorf("LSN(%d).String() = %q, want %q", tt.lsn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLSNRoundTrip(t *testing.T) {
+	inputs := []string{"0/16B3748", "0/0", "1/0", "FF/FFFFFFFF", "A/B"}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			lsn, err := ParseLSN(input)
+			if err != nil {
+				t.Fatalf("ParseLSN(%q) unexpected error: %v", input, err)
+			}
+			got := lsn.String()
+			if got != input {
+				t.Errorf("round-trip failed: %q → %d → %q", input, lsn, got)
+			}
+		})
+	}
+}
+
+func TestLSNComparison(t *testing.T) {
+	a, _ := ParseLSN("0/16B3748")
+	b, _ := ParseLSN("0/16B3749")
+	c, _ := ParseLSN("1/0")
+
+	if a >= b {
+		t.Errorf("expected %v < %v", a, b)
+	}
+	if b >= c {
+		t.Errorf("expected %v < %v", b, c)
+	}
+	if a >= c {
+		t.Errorf("expected %v < %v", a, c)
+	}
+
+	// equal
+	d, _ := ParseLSN("0/16B3748")
+	if a != d {
+		t.Errorf("expected %v == %v", a, d)
+	}
+}
+
+func TestLSNIsZero(t *testing.T) {
+	if !InvalidLSN.IsZero() {
+		t.Error("InvalidLSN should be zero")
+	}
+	lsn, _ := ParseLSN("0/1")
+	if lsn.IsZero() {
+		t.Error("non-zero LSN should not be zero")
+	}
+}


### PR DESCRIPTION
## Summary
- PostgreSQL LSN(`X/XXXXXXXX`) 포맷 파싱 및 `uint64` 변환 타입 구현
- `ParseLSN()`, `String()`, `IsZero()` 메서드 제공
- Round-trip, 비교, 에러 케이스 포함 단위 테스트

## Test plan
- [x] `ParseLSN` 정상/에러 케이스 테스트 통과
- [x] `String()` round-trip 테스트 통과
- [x] LSN 크기 비교 테스트 통과
- [x] 기존 전체 테스트 회귀 없음

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)