### PR TITLE
feat(router): LSN-Aware Reader 선택

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ tests/
 - `dbproxy_cache_hits_total` / `dbproxy_cache_misses_total` — 캐시 히트/미스
 - `dbproxy_cache_entries` — 현재 캐시 항목 수
 - `dbproxy_cache_invalidations_total` — 캐시 무효화 횟수
+- `dbproxy_reader_lsn_lag_bytes` — Reader별 WAL replay LSN (Causal Consistency 활성 시)
 
 ## 라이선스
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,10 +21,13 @@ type Metrics struct {
 	RateLimited prometheus.Counter
 
 	// Pool
-	PoolOpenConns *prometheus.GaugeVec
-	PoolIdleConns *prometheus.GaugeVec
-	PoolAcquires  *prometheus.CounterVec
+	PoolOpenConns  *prometheus.GaugeVec
+	PoolIdleConns  *prometheus.GaugeVec
+	PoolAcquires   *prometheus.CounterVec
 	PoolAcquireDur *prometheus.HistogramVec
+
+	// LSN replication lag
+	ReaderLSNLag *prometheus.GaugeVec
 }
 
 // New creates and registers all Prometheus metrics.
@@ -113,6 +116,14 @@ func New() *Metrics {
 			},
 			[]string{"role", "addr"},
 		),
+
+		ReaderLSNLag: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dbproxy_reader_lsn_lag_bytes",
+				Help: "Reader replication lag in bytes (writer LSN - reader replay LSN).",
+			},
+			[]string{"addr"},
+		),
 	}
 
 	prometheus.MustRegister(
@@ -128,6 +139,7 @@ func New() *Metrics {
 		m.PoolIdleConns,
 		m.PoolAcquires,
 		m.PoolAcquireDur,
+		m.ReaderLSNLag,
 	)
 
 	return m

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -206,6 +206,11 @@ func (s *Server) Start(ctx context.Context) error {
 		go s.invalidator.Subscribe(ctx)
 	}
 
+	// Start LSN polling for causal consistency
+	if s.cfg.Routing.CausalConsistency {
+		s.startLSNPolling(ctx, time.Second)
+	}
+
 	go func() {
 		<-ctx.Done()
 		ln.Close()
@@ -530,7 +535,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				}
 				// If !acquired && still in transaction → keep using boundWriter
 			} else {
-				if err := s.handleReadQuery(ctx, clientConn, msg, query); err != nil {
+				if err := s.handleReadQuery(ctx, clientConn, msg, query, session); err != nil {
 					slog.Error("handle read query", "error", err)
 					return
 				}
@@ -820,7 +825,7 @@ func (s *Server) queryCurrentLSN(writerConn net.Conn) (router.LSN, error) {
 }
 
 // handleReadQuery checks cache, acquires a reader from pool, or falls back to writer.
-func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string) error {
+func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session) error {
 	// Check cache
 	if s.queryCache != nil {
 		key := cache.CacheKey(query)
@@ -838,7 +843,13 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 	}
 
 	// Try to acquire a reader connection from pool
-	readerAddr := s.balancer.Next()
+	var readerAddr string
+	if s.cfg.Routing.CausalConsistency {
+		minLSN := session.LastWriteLSN()
+		readerAddr = s.balancer.NextWithLSN(minLSN)
+	} else {
+		readerAddr = s.balancer.Next()
+	}
 	if readerAddr == "" {
 		slog.Warn("no healthy reader, fallback to writer")
 		if s.metrics != nil {
@@ -1118,6 +1129,88 @@ func (s *Server) WriterPool() *pool.Pool {
 // Invalidator returns the server's cache invalidator (may be nil).
 func (s *Server) Invalidator() *cache.Invalidator {
 	return s.invalidator
+}
+
+// startLSNPolling periodically queries each reader's replay LSN and updates the balancer.
+func (s *Server) startLSNPolling(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.pollReaderLSNs(ctx)
+			}
+		}
+	}()
+	slog.Info("LSN polling started", "interval", interval)
+}
+
+// pollReaderLSNs queries each reader's replay LSN and updates the balancer.
+func (s *Server) pollReaderLSNs(ctx context.Context) {
+	for _, addr := range s.balancer.Backends() {
+		rPool, ok := s.readerPools[addr]
+		if !ok {
+			continue
+		}
+
+		conn, err := rPool.Acquire(ctx)
+		if err != nil {
+			slog.Debug("LSN poll: acquire reader failed", "addr", addr, "error", err)
+			continue
+		}
+
+		lsn, err := s.queryReplayLSN(conn)
+		rPool.Release(conn)
+		if err != nil {
+			slog.Debug("LSN poll: query replay LSN failed", "addr", addr, "error", err)
+			continue
+		}
+
+		s.balancer.SetReplayLSN(addr, lsn)
+
+		if s.metrics != nil {
+			s.metrics.ReaderLSNLag.WithLabelValues(addr).Set(float64(lsn))
+		}
+
+		slog.Debug("LSN poll updated", "addr", addr, "replay_lsn", lsn)
+	}
+}
+
+// queryReplayLSN queries the replay LSN from a reader connection.
+func (s *Server) queryReplayLSN(readerConn net.Conn) (router.LSN, error) {
+	payload := append([]byte("SELECT pg_last_wal_replay_lsn()"), 0)
+	if err := protocol.WriteMessage(readerConn, protocol.MsgQuery, payload); err != nil {
+		return 0, fmt.Errorf("send replay LSN query: %w", err)
+	}
+
+	var lsnStr string
+	for {
+		msg, err := protocol.ReadMessage(readerConn)
+		if err != nil {
+			return 0, fmt.Errorf("read replay LSN response: %w", err)
+		}
+		if msg.Type == protocol.MsgDataRow && len(msg.Payload) >= 6 {
+			colLen := int(binary.BigEndian.Uint32(msg.Payload[2:6]))
+			if colLen > 0 && 6+colLen <= len(msg.Payload) {
+				lsnStr = string(msg.Payload[6 : 6+colLen])
+			}
+		}
+		if msg.Type == protocol.MsgErrorResponse {
+			return 0, fmt.Errorf("replay LSN query returned error")
+		}
+		if msg.Type == protocol.MsgReadyForQuery {
+			break
+		}
+	}
+
+	if lsnStr == "" {
+		return 0, fmt.Errorf("no replay LSN value returned")
+	}
+	return router.ParseLSN(lsnStr)
 }
 
 func (s *Server) closePools() {

--- a/internal/router/balancer.go
+++ b/internal/router/balancer.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Backend struct {
-	Addr    string
-	healthy atomic.Bool
+	Addr      string
+	healthy   atomic.Bool
+	replayLSN atomic.Uint64 // latest replay LSN for this reader
 }
 
 type RoundRobin struct {
@@ -104,6 +105,67 @@ func (r *RoundRobin) UpdateBackends(addrs []string) {
 	r.backends = backends
 	r.mu.Unlock()
 	slog.Info("balancer backends updated", "count", len(addrs))
+}
+
+// NextWithLSN returns the next healthy backend whose replayLSN >= minLSN.
+// Returns empty string if no backend meets the criteria.
+func (r *RoundRobin) NextWithLSN(minLSN LSN) string {
+	if minLSN.IsZero() {
+		return r.Next()
+	}
+
+	r.mu.RLock()
+	backends := r.backends
+	r.mu.RUnlock()
+
+	n := len(backends)
+	if n == 0 {
+		return ""
+	}
+
+	for i := 0; i < n; i++ {
+		idx := int(r.index.Add(1)-1) % n
+		b := backends[idx]
+		if b.healthy.Load() && LSN(b.replayLSN.Load()) >= minLSN {
+			return b.Addr
+		}
+	}
+	return ""
+}
+
+// SetReplayLSN updates the replay LSN for a backend.
+func (r *RoundRobin) SetReplayLSN(addr string, lsn LSN) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, b := range r.backends {
+		if b.Addr == addr {
+			b.replayLSN.Store(uint64(lsn))
+			return
+		}
+	}
+}
+
+// ReplayLSN returns the replay LSN for a backend.
+func (r *RoundRobin) ReplayLSN(addr string) LSN {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, b := range r.backends {
+		if b.Addr == addr {
+			return LSN(b.replayLSN.Load())
+		}
+	}
+	return InvalidLSN
+}
+
+// Backends returns the list of backend addresses.
+func (r *RoundRobin) Backends() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	addrs := make([]string, len(r.backends))
+	for i, b := range r.backends {
+		addrs[i] = b.Addr
+	}
+	return addrs
 }
 
 // HealthyCount returns the number of healthy backends.

--- a/internal/router/balancer_test.go
+++ b/internal/router/balancer_test.go
@@ -94,6 +94,74 @@ func TestRoundRobin_UpdateBackends(t *testing.T) {
 	}
 }
 
+func TestRoundRobin_NextWithLSN(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+
+	// Set replay LSNs: a=100, b=200, c=150
+	rb.SetReplayLSN("a:1", LSN(100))
+	rb.SetReplayLSN("b:2", LSN(200))
+	rb.SetReplayLSN("c:3", LSN(150))
+
+	// minLSN=0 → same as Next(), returns any healthy
+	addr := rb.NextWithLSN(InvalidLSN)
+	if addr == "" {
+		t.Error("NextWithLSN(0) should return a backend")
+	}
+
+	// minLSN=180 → only b:2 qualifies (200 >= 180)
+	counts := map[string]int{}
+	for i := 0; i < 6; i++ {
+		addr := rb.NextWithLSN(LSN(180))
+		counts[addr]++
+	}
+	if counts["b:2"] != 6 {
+		t.Errorf("expected only b:2 for minLSN=180, got %v", counts)
+	}
+
+	// minLSN=250 → none qualify
+	if addr := rb.NextWithLSN(LSN(250)); addr != "" {
+		t.Errorf("NextWithLSN(250) = %q, want empty", addr)
+	}
+}
+
+func TestRoundRobin_NextWithLSN_SkipsUnhealthy(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2"})
+	rb.SetReplayLSN("a:1", LSN(200))
+	rb.SetReplayLSN("b:2", LSN(200))
+
+	rb.MarkUnhealthy("a:1")
+
+	// Only b:2 is healthy and has sufficient LSN
+	for i := 0; i < 4; i++ {
+		addr := rb.NextWithLSN(LSN(100))
+		if addr != "b:2" {
+			t.Errorf("expected b:2, got %q", addr)
+		}
+	}
+}
+
+func TestRoundRobin_SetReplayLSN(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2"})
+
+	rb.SetReplayLSN("a:1", LSN(12345))
+	if got := rb.ReplayLSN("a:1"); got != LSN(12345) {
+		t.Errorf("ReplayLSN(a:1) = %d, want 12345", got)
+	}
+
+	// Unknown addr returns InvalidLSN
+	if got := rb.ReplayLSN("unknown:1"); got != InvalidLSN {
+		t.Errorf("ReplayLSN(unknown) = %d, want 0", got)
+	}
+}
+
+func TestRoundRobin_Backends(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+	addrs := rb.Backends()
+	if len(addrs) != 3 {
+		t.Errorf("Backends() len = %d, want 3", len(addrs))
+	}
+}
+
 func TestRoundRobin_Recovery(t *testing.T) {
 	// Start a real TCP server to simulate recovery
 	ln, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
- Backend에 `replayLSN` 필드 추가 (atomic.Uint64 기반 lock-free 접근)
- `NextWithLSN(minLSN)` — 세션 LSN 이상인 healthy Reader만 라운드로빈 선택
- Server에서 1초 간격으로 각 Reader의 `pg_last_wal_replay_lsn()` 폴링
- `handleReadQuery`에서 causal consistency 모드 시 LSN-aware 밸런서 사용
- `dbproxy_reader_lsn_lag_bytes` Prometheus 메트릭 추가

## Test plan
- [x] `TestRoundRobin_NextWithLSN` — LSN 기반 Reader 선택 동작
- [x] `TestRoundRobin_NextWithLSN_SkipsUnhealthy` — 비정상 Reader 스킵
- [x] `TestRoundRobin_SetReplayLSN` — LSN 저장/조회
- [x] `TestRoundRobin_Backends` — 백엔드 목록 조회
- [x] 기존 전체 테스트 회귀 없음

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)