### PR TITLE
refactor(router): Classify/ExtractTables AST 기반 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ pool:
 routing:
   read_after_write_delay: 500ms  # 타이머 기반 (causal_consistency와 양자택일)
   causal_consistency: false       # true: LSN 기반 Causal Consistency (read_after_write_delay 무시)
+  ast_parser: false               # true: pg_query_go AST 파서 사용 (정확도↑, 성능 약간↓)
 
 cache:
   enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type PoolConfig struct {
 type RoutingConfig struct {
 	ReadAfterWriteDelay time.Duration `yaml:"read_after_write_delay"`
 	CausalConsistency   bool          `yaml:"causal_consistency"`
+	ASTParser           bool          `yaml:"ast_parser"`
 }
 
 type CacheConfig struct {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -763,7 +763,7 @@ func (s *Server) handleWriteQuery(clientConn net.Conn, writerConn net.Conn, msg 
 	}
 
 	// Track WAL LSN for causal consistency
-	if s.cfg.Routing.CausalConsistency && router.Classify(query) == router.QueryWrite {
+	if s.cfg.Routing.CausalConsistency && s.classifyQuery(query) == router.QueryWrite {
 		if lsn, err := s.queryCurrentLSN(writerConn); err != nil {
 			slog.Warn("query WAL LSN after write", "error", err)
 		} else {
@@ -773,8 +773,8 @@ func (s *Server) handleWriteQuery(clientConn net.Conn, writerConn net.Conn, msg 
 	}
 
 	// Invalidate cache for affected tables
-	if s.queryCache != nil && router.Classify(query) == router.QueryWrite {
-		tables := router.ExtractTables(query)
+	if s.queryCache != nil && s.classifyQuery(query) == router.QueryWrite {
+		tables := s.extractQueryTables(query)
 		for _, table := range tables {
 			s.queryCache.InvalidateTable(table)
 			if s.metrics != nil {
@@ -1307,6 +1307,22 @@ func (s *Server) Reload(newCfg *config.Config) error {
 // CfgPath returns the config file path (stored externally by main).
 func (s *Server) Cfg() *config.Config {
 	return s.cfg
+}
+
+// classifyQuery uses AST or string parser based on config.
+func (s *Server) classifyQuery(query string) router.QueryType {
+	if s.cfg.Routing.ASTParser {
+		return router.ClassifyAST(query)
+	}
+	return router.Classify(query)
+}
+
+// extractQueryTables uses AST or string parser based on config.
+func (s *Server) extractQueryTables(query string) []string {
+	if s.cfg.Routing.ASTParser {
+		return router.ExtractTablesAST(query)
+	}
+	return router.ExtractTables(query)
 }
 
 func routeName(r router.Route) string {

--- a/internal/router/parser_ast.go
+++ b/internal/router/parser_ast.go
@@ -1,0 +1,180 @@
+package router
+
+import (
+	"log/slog"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v5"
+)
+
+// ClassifyAST determines whether a query is a read or write operation using AST parsing.
+// Falls back to string-based Classify on parse errors.
+func ClassifyAST(query string) QueryType {
+	// 1. Check for routing hint (same logic as string parser)
+	if hint := extractHint(query); hint != "" {
+		if hint == "writer" {
+			return QueryWrite
+		}
+		return QueryRead
+	}
+
+	// 2. Parse SQL to AST
+	tree, err := ParseSQL(query)
+	if err != nil {
+		slog.Debug("AST parse failed, fallback to string parser", "error", err)
+		return Classify(query)
+	}
+
+	// 3. Check each statement
+	for _, rawStmt := range tree.GetStmts() {
+		stmt := rawStmt.GetStmt()
+		if stmt == nil {
+			continue
+		}
+		if isWriteNode(stmt) {
+			return QueryWrite
+		}
+	}
+
+	return QueryRead
+}
+
+// isWriteNode checks if a node represents a write operation.
+func isWriteNode(node *pg_query.Node) bool {
+	switch n := node.GetNode().(type) {
+	case *pg_query.Node_InsertStmt:
+		return true
+	case *pg_query.Node_UpdateStmt:
+		return true
+	case *pg_query.Node_DeleteStmt:
+		return true
+	case *pg_query.Node_CreateStmt:
+		return true
+	case *pg_query.Node_AlterTableStmt:
+		return true
+	case *pg_query.Node_DropStmt:
+		return true
+	case *pg_query.Node_TruncateStmt:
+		return true
+	case *pg_query.Node_GrantStmt:
+		return true
+	case *pg_query.Node_GrantRoleStmt:
+		return true
+	case *pg_query.Node_CreateSchemaStmt:
+		return true
+	case *pg_query.Node_IndexStmt:
+		return true
+	case *pg_query.Node_CreateSeqStmt:
+		return true
+	case *pg_query.Node_AlterSeqStmt:
+		return true
+	case *pg_query.Node_ViewStmt:
+		return true
+	case *pg_query.Node_CreateFunctionStmt:
+		return true
+	case *pg_query.Node_CreateTrigStmt:
+		return true
+	case *pg_query.Node_RenameStmt:
+		return true
+	case *pg_query.Node_CommentStmt:
+		return true
+	case *pg_query.Node_SelectStmt:
+		// CTE with write operations: WITH ... AS (INSERT/UPDATE/DELETE ...)
+		s := n.SelectStmt
+		if s.GetWithClause() != nil {
+			for _, cte := range s.GetWithClause().GetCtes() {
+				if ce := cte.GetCommonTableExpr(); ce != nil {
+					if ce.GetCtequery() != nil && isWriteNode(ce.GetCtequery()) {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// ExtractTablesAST extracts table names from write queries using AST parsing.
+// Falls back to string-based ExtractTables on parse errors.
+func ExtractTablesAST(query string) []string {
+	tree, err := ParseSQL(query)
+	if err != nil {
+		slog.Debug("AST parse failed for table extraction, fallback", "error", err)
+		return ExtractTables(query)
+	}
+
+	seen := make(map[string]bool)
+	var tables []string
+
+	for _, rawStmt := range tree.GetStmts() {
+		stmt := rawStmt.GetStmt()
+		if stmt == nil {
+			continue
+		}
+
+		extractWriteTables(stmt, func(table string) {
+			t := strings.ToLower(table)
+			if t != "" && !seen[t] {
+				seen[t] = true
+				tables = append(tables, t)
+			}
+		})
+	}
+
+	return tables
+}
+
+// extractWriteTables collects table names from write operations.
+func extractWriteTables(node *pg_query.Node, add func(string)) {
+	switch n := node.GetNode().(type) {
+	case *pg_query.Node_InsertStmt:
+		extractCTEWriteTables(n.InsertStmt.GetWithClause(), add)
+		if rel := n.InsertStmt.GetRelation(); rel != nil {
+			add(rel.GetRelname())
+		}
+	case *pg_query.Node_UpdateStmt:
+		extractCTEWriteTables(n.UpdateStmt.GetWithClause(), add)
+		if rel := n.UpdateStmt.GetRelation(); rel != nil {
+			add(rel.GetRelname())
+		}
+	case *pg_query.Node_DeleteStmt:
+		extractCTEWriteTables(n.DeleteStmt.GetWithClause(), add)
+		if rel := n.DeleteStmt.GetRelation(); rel != nil {
+			add(rel.GetRelname())
+		}
+	case *pg_query.Node_TruncateStmt:
+		for _, arg := range n.TruncateStmt.GetRelations() {
+			if rv := arg.GetRangeVar(); rv != nil {
+				add(rv.GetRelname())
+			}
+		}
+	case *pg_query.Node_DropStmt:
+		for _, obj := range n.DropStmt.GetObjects() {
+			if list := obj.GetList(); list != nil {
+				for _, item := range list.GetItems() {
+					if s := item.GetString_(); s != nil {
+						add(s.GetSval())
+					}
+				}
+			}
+		}
+	case *pg_query.Node_SelectStmt:
+		extractCTEWriteTables(n.SelectStmt.GetWithClause(), add)
+	}
+}
+
+// extractCTEWriteTables extracts write table names from CTE clauses.
+func extractCTEWriteTables(wc *pg_query.WithClause, add func(string)) {
+	if wc == nil {
+		return
+	}
+	for _, cte := range wc.GetCtes() {
+		if ce := cte.GetCommonTableExpr(); ce != nil {
+			if ce.GetCtequery() != nil {
+				extractWriteTables(ce.GetCtequery(), add)
+			}
+		}
+	}
+}

--- a/internal/router/parser_ast_test.go
+++ b/internal/router/parser_ast_test.go
@@ -1,0 +1,236 @@
+package router
+
+import "testing"
+
+func TestClassifyAST(t *testing.T) {
+	tests := []struct {
+		query string
+		want  QueryType
+	}{
+		{"SELECT * FROM users", QueryRead},
+		{"select * from users", QueryRead},
+		{"  SELECT 1", QueryRead},
+		{"SHOW tables", QueryRead},
+		{"EXPLAIN SELECT 1", QueryRead},
+		{"INSERT INTO users VALUES (1)", QueryWrite},
+		{"insert into users values (1)", QueryWrite},
+		{"UPDATE users SET name = 'a'", QueryWrite},
+		{"DELETE FROM users WHERE id = 1", QueryWrite},
+		{"CREATE TABLE foo (id int)", QueryWrite},
+		{"ALTER TABLE foo ADD COLUMN col int", QueryWrite},
+		{"DROP TABLE foo", QueryWrite},
+		{"TRUNCATE users", QueryWrite},
+		// Hint comments
+		{"/* route:writer */ SELECT * FROM users", QueryWrite},
+		{"/* route:reader */ INSERT INTO users VALUES (1)", QueryRead},
+		{"/*route:writer*/ SELECT 1", QueryWrite},
+		{"/* route:reader */ SELECT 1", QueryRead},
+		// Regular comments should not trigger writes
+		{"-- comment\nSELECT 1", QueryRead},
+		{"/* normal comment */ SELECT 1", QueryRead},
+		// GRANT/REVOKE
+		{"GRANT SELECT ON users TO readonly", QueryWrite},
+		// CREATE INDEX
+		{"CREATE INDEX idx ON users (name)", QueryWrite},
+		// CREATE VIEW
+		{"CREATE VIEW v AS SELECT * FROM users", QueryWrite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := ClassifyAST(tt.query)
+			if got != tt.want {
+				t.Errorf("ClassifyAST(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAST_MultiStatement(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  QueryType
+	}{
+		{"insert in multi", "SELECT 1; INSERT INTO users VALUES(1);", QueryWrite},
+		{"CTE with update", "WITH x AS (UPDATE users SET score=0 RETURNING id) SELECT * FROM x", QueryWrite},
+		{"CTE with delete", "WITH d AS (DELETE FROM old_logs RETURNING id) INSERT INTO archive SELECT * FROM d", QueryWrite},
+		{"pure CTE read", "WITH x AS (SELECT * FROM users) SELECT * FROM x", QueryRead},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAST(tt.query)
+			if got != tt.want {
+				t.Errorf("ClassifyAST(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAST_DollarQuoting(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  QueryType
+	}{
+		{
+			"keyword inside $$ should not trigger write",
+			"SELECT $$ INSERT INTO users VALUES(1) $$",
+			QueryRead,
+		},
+		{
+			"keyword inside $tag$ should not trigger write",
+			"SELECT $body$ DELETE FROM users $body$",
+			QueryRead,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAST(tt.query)
+			if got != tt.want {
+				t.Errorf("ClassifyAST(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAST_NestedComments(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  QueryType
+	}{
+		{
+			"nested comment hides UPDATE",
+			"SELECT /* /* UPDATE admin SET foo='bar' */ */ 1",
+			QueryRead,
+		},
+		{
+			"triple nested comment",
+			"SELECT /* /* /* */ */ */ 1",
+			QueryRead,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAST(tt.query)
+			if got != tt.want {
+				t.Errorf("ClassifyAST(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTablesAST(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"INSERT INTO users VALUES (1)", "users"},
+		{"insert into users values (1)", "users"},
+		{"UPDATE orders SET status = 'done'", "orders"},
+		{"DELETE FROM products WHERE id = 1", "products"},
+		{"TRUNCATE TABLE logs", "logs"},
+		{"INSERT INTO public.users VALUES (1)", "users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			tables := ExtractTablesAST(tt.query)
+			if len(tables) == 0 {
+				t.Fatalf("ExtractTablesAST(%q) returned empty", tt.query)
+			}
+			if tables[0] != tt.want {
+				t.Errorf("ExtractTablesAST(%q) = %q, want %q", tt.query, tables[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTablesAST_MultiTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantCount int
+		wantAll   []string
+	}{
+		{
+			"CTE with two writes",
+			"WITH x AS (UPDATE users SET score=0) UPDATE ranking SET total=0",
+			2,
+			[]string{"users", "ranking"},
+		},
+		{
+			"multi-statement insert+delete",
+			"INSERT INTO users VALUES(1); DELETE FROM logs WHERE id=1;",
+			2,
+			[]string{"users", "logs"},
+		},
+		{
+			"CTE delete into insert",
+			"WITH d AS (DELETE FROM old_logs RETURNING id) INSERT INTO archive SELECT * FROM d",
+			2,
+			nil, // order may vary, just check count
+		},
+		{
+			"single table",
+			"UPDATE orders SET status='done'",
+			1,
+			[]string{"orders"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tables := ExtractTablesAST(tt.query)
+			if len(tables) != tt.wantCount {
+				t.Errorf("ExtractTablesAST(%q) got %d tables %v, want %d", tt.query, len(tables), tables, tt.wantCount)
+				return
+			}
+			if tt.wantAll != nil {
+				for i, want := range tt.wantAll {
+					if i >= len(tables) {
+						break
+					}
+					if tables[i] != want {
+						t.Errorf("tables[%d] = %q, want %q", i, tables[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractTablesAST_QuotedNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			"double-quoted table",
+			`INSERT INTO "Order Items" VALUES (1)`,
+			"order items",
+		},
+		{
+			"quoted schema.table",
+			`UPDATE public."my table" SET a=1`,
+			"my table",
+		},
+		{
+			"DELETE FROM quoted table",
+			`DELETE FROM "user data" WHERE id=1`,
+			"user data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tables := ExtractTablesAST(tt.query)
+			if len(tables) == 0 {
+				t.Fatalf("ExtractTablesAST(%q) returned empty", tt.query)
+			}
+			if tables[0] != tt.want {
+				t.Errorf("ExtractTablesAST(%q) = %q, want %q", tt.query, tables[0], tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `ClassifyAST()`: AST 루트 노드로 read/write 판별 — DDL/DML 전체 커버
- `ExtractTablesAST()`: RangeVar 노드에서 테이블명 추출 — CTE 재귀 지원
- `routing.ast_parser: true` 설정으로 AST 파서 활성화 (기본값 false)
- 파싱 실패 시 기존 문자열 파서로 자동 fallback

## Test plan
- [x] ClassifyAST — 기존 Classify 테스트 케이스 전체 + Dollar Quoting/Nested Comments
- [x] ExtractTablesAST — 단일/다중/CTE/Quoted 테이블명 추출
- [x] 기존 전체 테스트 회귀 없음

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)