### PR TITLE
feat(router): AST 기반 쿼리 방화벽

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ routing:
   causal_consistency: false       # true: LSN 기반 Causal Consistency (read_after_write_delay 무시)
   ast_parser: false               # true: pg_query_go AST 파서 사용 (정확도↑, 성능 약간↓)
 
+firewall:
+  enabled: true
+  block_delete_without_where: true
+  block_update_without_where: true
+  block_drop_table: false
+  block_truncate: false
+
 cache:
   enabled: true
   cache_ttl: 10s
@@ -183,6 +190,7 @@ tests/
 - `dbproxy_cache_entries` — 현재 캐시 항목 수
 - `dbproxy_cache_invalidations_total` — 캐시 무효화 횟수
 - `dbproxy_reader_lsn_lag_bytes` — Reader별 WAL replay LSN (Causal Consistency 활성 시)
+- `dbproxy_firewall_blocked_total` — 방화벽 차단 횟수 (rule별)
 
 ## 라이선스
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,15 @@ type Config struct {
 	Auth           AuthConfig           `yaml:"auth"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
 	RateLimit      RateLimitConfig      `yaml:"rate_limit"`
+	Firewall       FirewallConfig       `yaml:"firewall"`
+}
+
+type FirewallConfig struct {
+	Enabled                 bool `yaml:"enabled"`
+	BlockDeleteWithoutWhere bool `yaml:"block_delete_without_where"`
+	BlockUpdateWithoutWhere bool `yaml:"block_update_without_where"`
+	BlockDropTable          bool `yaml:"block_drop_table"`
+	BlockTruncate           bool `yaml:"block_truncate"`
 }
 
 type MetricsConfig struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -28,6 +28,9 @@ type Metrics struct {
 
 	// LSN replication lag
 	ReaderLSNLag *prometheus.GaugeVec
+
+	// Firewall
+	FirewallBlocked *prometheus.CounterVec
 }
 
 // New creates and registers all Prometheus metrics.
@@ -124,6 +127,14 @@ func New() *Metrics {
 			},
 			[]string{"addr"},
 		),
+
+		FirewallBlocked: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dbproxy_firewall_blocked_total",
+				Help: "Total number of queries blocked by firewall rules.",
+			},
+			[]string{"rule"},
+		),
 	}
 
 	prometheus.MustRegister(
@@ -140,6 +151,7 @@ func New() *Metrics {
 		m.PoolAcquires,
 		m.PoolAcquireDur,
 		m.ReaderLSNLag,
+		m.FirewallBlocked,
 	)
 
 	return m

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -501,6 +501,26 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 		if msg.Type == protocol.MsgQuery {
 			query := protocol.ExtractQueryText(msg.Payload)
 
+			// Firewall check
+			if s.cfg.Firewall.Enabled {
+				fwResult := router.CheckFirewall(query, router.FirewallConfig{
+					Enabled:                 s.cfg.Firewall.Enabled,
+					BlockDeleteWithoutWhere: s.cfg.Firewall.BlockDeleteWithoutWhere,
+					BlockUpdateWithoutWhere: s.cfg.Firewall.BlockUpdateWithoutWhere,
+					BlockDropTable:          s.cfg.Firewall.BlockDropTable,
+					BlockTruncate:           s.cfg.Firewall.BlockTruncate,
+				})
+				if fwResult.Blocked {
+					slog.Warn("firewall blocked query", "rule", fwResult.Rule, "sql", query)
+					if s.metrics != nil {
+						s.metrics.FirewallBlocked.WithLabelValues(string(fwResult.Rule)).Inc()
+					}
+					s.sendError(clientConn, fwResult.Message)
+					protocol.WriteMessage(clientConn, protocol.MsgReadyForQuery, []byte{'I'})
+					continue
+				}
+			}
+
 			wasInTx := session.InTransaction()
 			route := session.Route(query)
 			nowInTx := session.InTransaction()

--- a/internal/router/firewall.go
+++ b/internal/router/firewall.go
@@ -1,0 +1,110 @@
+package router
+
+import (
+	"fmt"
+
+	pg_query "github.com/pganalyze/pg_query_go/v5"
+)
+
+// FirewallRule identifies which rule blocked a query.
+type FirewallRule string
+
+const (
+	RuleDeleteNoWhere FirewallRule = "delete_no_where"
+	RuleUpdateNoWhere FirewallRule = "update_no_where"
+	RuleDropTable     FirewallRule = "drop_table"
+	RuleTruncate      FirewallRule = "truncate"
+)
+
+// FirewallConfig mirrors config.FirewallConfig for the router package.
+type FirewallConfig struct {
+	Enabled                 bool
+	BlockDeleteWithoutWhere bool
+	BlockUpdateWithoutWhere bool
+	BlockDropTable          bool
+	BlockTruncate           bool
+}
+
+// FirewallResult contains the outcome of a firewall check.
+type FirewallResult struct {
+	Blocked bool
+	Rule    FirewallRule
+	Message string
+}
+
+// CheckFirewall inspects a query against firewall rules using AST parsing.
+// Returns a FirewallResult indicating if the query is blocked.
+func CheckFirewall(query string, cfg FirewallConfig) FirewallResult {
+	if !cfg.Enabled {
+		return FirewallResult{}
+	}
+
+	tree, err := ParseSQL(query)
+	if err != nil {
+		// Can't parse → allow (fail-open for firewall; safety is in the DB)
+		return FirewallResult{}
+	}
+
+	for _, rawStmt := range tree.GetStmts() {
+		stmt := rawStmt.GetStmt()
+		if stmt == nil {
+			continue
+		}
+
+		if result := checkNode(stmt, cfg); result.Blocked {
+			return result
+		}
+	}
+
+	return FirewallResult{}
+}
+
+func checkNode(node *pg_query.Node, cfg FirewallConfig) FirewallResult {
+	switch n := node.GetNode().(type) {
+	case *pg_query.Node_DeleteStmt:
+		if cfg.BlockDeleteWithoutWhere && n.DeleteStmt.GetWhereClause() == nil {
+			table := ""
+			if rel := n.DeleteStmt.GetRelation(); rel != nil {
+				table = rel.GetRelname()
+			}
+			return FirewallResult{
+				Blocked: true,
+				Rule:    RuleDeleteNoWhere,
+				Message: fmt.Sprintf("DELETE without WHERE clause on table %q is blocked by firewall", table),
+			}
+		}
+
+	case *pg_query.Node_UpdateStmt:
+		if cfg.BlockUpdateWithoutWhere && n.UpdateStmt.GetWhereClause() == nil {
+			table := ""
+			if rel := n.UpdateStmt.GetRelation(); rel != nil {
+				table = rel.GetRelname()
+			}
+			return FirewallResult{
+				Blocked: true,
+				Rule:    RuleUpdateNoWhere,
+				Message: fmt.Sprintf("UPDATE without WHERE clause on table %q is blocked by firewall", table),
+			}
+		}
+
+	case *pg_query.Node_DropStmt:
+		if cfg.BlockDropTable {
+			return FirewallResult{
+				Blocked: true,
+				Rule:    RuleDropTable,
+				Message: "DROP statement is blocked by firewall",
+			}
+		}
+
+	case *pg_query.Node_TruncateStmt:
+		if cfg.BlockTruncate {
+			return FirewallResult{
+				Blocked: true,
+				Rule:    RuleTruncate,
+				Message: "TRUNCATE statement is blocked by firewall",
+			}
+		}
+	}
+
+	return FirewallResult{}
+}

--- a/internal/router/firewall_test.go
+++ b/internal/router/firewall_test.go
@@ -1,0 +1,160 @@
+package router
+
+import "testing"
+
+func TestCheckFirewall_DeleteWithoutWhere(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:                 true,
+		BlockDeleteWithoutWhere: true,
+	}
+
+	// Blocked: DELETE without WHERE
+	result := CheckFirewall("DELETE FROM users", cfg)
+	if !result.Blocked {
+		t.Error("expected DELETE without WHERE to be blocked")
+	}
+	if result.Rule != RuleDeleteNoWhere {
+		t.Errorf("rule = %q, want %q", result.Rule, RuleDeleteNoWhere)
+	}
+
+	// Allowed: DELETE with WHERE
+	result = CheckFirewall("DELETE FROM users WHERE id = 1", cfg)
+	if result.Blocked {
+		t.Error("expected DELETE with WHERE to be allowed")
+	}
+
+	// Allowed: SELECT
+	result = CheckFirewall("SELECT * FROM users", cfg)
+	if result.Blocked {
+		t.Error("expected SELECT to be allowed")
+	}
+}
+
+func TestCheckFirewall_UpdateWithoutWhere(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:                 true,
+		BlockUpdateWithoutWhere: true,
+	}
+
+	// Blocked: UPDATE without WHERE
+	result := CheckFirewall("UPDATE users SET active = false", cfg)
+	if !result.Blocked {
+		t.Error("expected UPDATE without WHERE to be blocked")
+	}
+	if result.Rule != RuleUpdateNoWhere {
+		t.Errorf("rule = %q, want %q", result.Rule, RuleUpdateNoWhere)
+	}
+
+	// Allowed: UPDATE with WHERE
+	result = CheckFirewall("UPDATE users SET active = false WHERE id = 1", cfg)
+	if result.Blocked {
+		t.Error("expected UPDATE with WHERE to be allowed")
+	}
+}
+
+func TestCheckFirewall_DropTable(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:        true,
+		BlockDropTable: true,
+	}
+
+	result := CheckFirewall("DROP TABLE users", cfg)
+	if !result.Blocked {
+		t.Error("expected DROP TABLE to be blocked")
+	}
+	if result.Rule != RuleDropTable {
+		t.Errorf("rule = %q, want %q", result.Rule, RuleDropTable)
+	}
+
+	// DROP INDEX should also be blocked (it's a DropStmt)
+	result = CheckFirewall("DROP INDEX idx_users_name", cfg)
+	if !result.Blocked {
+		t.Error("expected DROP INDEX to be blocked")
+	}
+}
+
+func TestCheckFirewall_Truncate(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:       true,
+		BlockTruncate: true,
+	}
+
+	result := CheckFirewall("TRUNCATE users", cfg)
+	if !result.Blocked {
+		t.Error("expected TRUNCATE to be blocked")
+	}
+	if result.Rule != RuleTruncate {
+		t.Errorf("rule = %q, want %q", result.Rule, RuleTruncate)
+	}
+}
+
+func TestCheckFirewall_Disabled(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:                 false,
+		BlockDeleteWithoutWhere: true,
+	}
+
+	result := CheckFirewall("DELETE FROM users", cfg)
+	if result.Blocked {
+		t.Error("expected firewall disabled to allow all queries")
+	}
+}
+
+func TestCheckFirewall_MultiStatement(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:                 true,
+		BlockDeleteWithoutWhere: true,
+	}
+
+	// First statement is fine, second is blocked
+	result := CheckFirewall("SELECT 1; DELETE FROM users;", cfg)
+	if !result.Blocked {
+		t.Error("expected multi-statement with DELETE without WHERE to be blocked")
+	}
+}
+
+func TestCheckFirewall_AllRulesEnabled(t *testing.T) {
+	cfg := FirewallConfig{
+		Enabled:                 true,
+		BlockDeleteWithoutWhere: true,
+		BlockUpdateWithoutWhere: true,
+		BlockDropTable:          true,
+		BlockTruncate:           true,
+	}
+
+	// All these should be blocked
+	blocked := []struct {
+		query string
+		rule  FirewallRule
+	}{
+		{"DELETE FROM users", RuleDeleteNoWhere},
+		{"UPDATE users SET x=1", RuleUpdateNoWhere},
+		{"DROP TABLE users", RuleDropTable},
+		{"TRUNCATE users", RuleTruncate},
+	}
+
+	for _, tt := range blocked {
+		result := CheckFirewall(tt.query, cfg)
+		if !result.Blocked {
+			t.Errorf("expected %q to be blocked", tt.query)
+		}
+		if result.Rule != tt.rule {
+			t.Errorf("%q: rule = %q, want %q", tt.query, result.Rule, tt.rule)
+		}
+	}
+
+	// All these should be allowed
+	allowed := []string{
+		"SELECT * FROM users",
+		"INSERT INTO users VALUES (1)",
+		"DELETE FROM users WHERE id = 1",
+		"UPDATE users SET x=1 WHERE id = 1",
+	}
+
+	for _, q := range allowed {
+		result := CheckFirewall(q, cfg)
+		if result.Blocked {
+			t.Errorf("expected %q to be allowed, blocked by %q", q, result.Rule)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `CheckFirewall()` — AST 검사로 위험 쿼리 프록시 단 차단
- 4가지 규칙: DELETE/UPDATE without WHERE, DROP TABLE, TRUNCATE (각각 ON/OFF)
- Simple Query 처리 전 방화벽 체크, 차단 시 ErrorResponse + ReadyForQuery 반환
- `dbproxy_firewall_blocked_total{rule}` Prometheus 카운터 메트릭

## Test plan
- [x] DELETE/UPDATE without WHERE 차단/허용 테스트
- [x] DROP TABLE, TRUNCATE 차단 테스트
- [x] 비활성 시 모든 쿼리 허용 테스트
- [x] Multi-statement 차단 테스트
- [x] 기존 전체 테스트 회귀 없음

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)