### PR TITLE
fix(cache): SemanticCacheKey 캐시 충돌 수정 (#70)

### DIFF
--- a/internal/cache/normalize.go
+++ b/internal/cache/normalize.go
@@ -8,17 +8,25 @@ import (
 )
 
 // SemanticCacheKey generates a cache key from a normalized AST representation.
-// Semantically equivalent queries (different whitespace, literal values, WHERE clause order)
-// produce the same key. Falls back to CacheKey on parse failure.
+// Semantically equivalent queries (different whitespace, casing) produce the same key
+// while preserving literal values to prevent cross-query cache collisions.
+// Falls back to CacheKey on parse failure.
 func SemanticCacheKey(query string) uint64 {
-	// Step 1: Fingerprint — pg_query_go normalizes whitespace, casing, and replaces
-	// constants with placeholders. Structurally identical queries get the same fingerprint.
-	fp, err := pg_query.FingerprintToUInt64(query)
+	// Parse → Deparse normalizes whitespace and casing while preserving literal values.
+	// Unlike FingerprintToUInt64 which strips all constants, Deparse keeps them intact.
+	tree, err := pg_query.Parse(query)
 	if err != nil {
-		slog.Debug("semantic cache key: fingerprint failed, fallback", "error", err)
+		slog.Debug("semantic cache key: parse failed, fallback", "error", err)
 		return CacheKey(query)
 	}
-	return fp
+	deparsed, err := pg_query.Deparse(tree)
+	if err != nil {
+		slog.Debug("semantic cache key: deparse failed, fallback", "error", err)
+		return CacheKey(query)
+	}
+	h := fnv.New64a()
+	h.Write([]byte(deparsed))
+	return h.Sum64()
 }
 
 // NormalizeQuery returns a canonical string representation of the query

--- a/internal/cache/normalize_test.go
+++ b/internal/cache/normalize_test.go
@@ -15,13 +15,13 @@ func TestSemanticCacheKey_WhitespaceInsensitive(t *testing.T) {
 	}
 }
 
-func TestSemanticCacheKey_LiteralInsensitive(t *testing.T) {
-	// Same structure, different literal values → same fingerprint
+func TestSemanticCacheKey_LiteralSensitive(t *testing.T) {
+	// Same structure, different literal values → different keys (prevents cache collision)
 	k1 := SemanticCacheKey("SELECT * FROM users WHERE id = 1")
 	k2 := SemanticCacheKey("SELECT * FROM users WHERE id = 999")
 
-	if k1 != k2 {
-		t.Errorf("different literals should produce same fingerprint: key1 (%d) != key2 (%d)", k1, k2)
+	if k1 == k2 {
+		t.Errorf("different literals must produce different keys to prevent cache collision: %d", k1)
 	}
 }
 

--- a/internal/cache/semantic_cache_test.go
+++ b/internal/cache/semantic_cache_test.go
@@ -1,0 +1,27 @@
+package cache
+
+import "testing"
+
+func TestSemanticCacheCollision(t *testing.T) {
+	q1 := "SELECT * FROM users WHERE id = 1"
+	q2 := "SELECT * FROM users WHERE id = 2"
+
+	key1 := SemanticCacheKey(q1)
+	key2 := SemanticCacheKey(q2)
+
+	if key1 == key2 {
+		t.Errorf("VULNERABLE: different literal values must produce different cache keys: %d", key1)
+	}
+}
+
+func TestSemanticCacheEquivalence(t *testing.T) {
+	q1 := "SELECT * FROM users WHERE id = 1"
+	q2 := "select  *  from  users  where  id  =  1"
+
+	key1 := SemanticCacheKey(q1)
+	key2 := SemanticCacheKey(q2)
+
+	if key1 != key2 {
+		t.Errorf("semantically equivalent queries should produce the same cache key: %d != %d", key1, key2)
+	}
+}


### PR DESCRIPTION
## Summary
- `SemanticCacheKey`가 `FingerprintToUInt64`를 사용하여 리터럴 값을 제거 → 다른 파라미터의 쿼리가 동일 캐시 키 생성 → 타 유저 데이터 노출
- `Parse` + `Deparse`로 교체하여 정규화된 SQL(리터럴 보존)을 해싱하도록 수정
- 기존 테스트(`LiteralInsensitive` → `LiteralSensitive`)를 올바른 동작 기준으로 변경

## Test plan
- [x] `TestSemanticCacheCollision` — 다른 리터럴 값이 다른 키 생성 확인
- [x] `TestSemanticCacheEquivalence` — 동일 쿼리의 whitespace/case 차이는 동일 키 확인
- [x] 기존 전체 cache 테스트 통과

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)