### PR TITLE
fix(proxy): cacheKey 무한 재귀 수정 (#71)

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -1334,7 +1334,7 @@ func (s *Server) cacheKey(query string) uint64 {
 	if s.cfg.Routing.ASTParser {
 		return cache.SemanticCacheKey(query)
 	}
-	return s.cacheKey(query)
+	return cache.CacheKey(query)
 }
 
 // classifyQuery uses AST or string parser based on config.


### PR DESCRIPTION
## Summary
- `server.go:1337`에서 `ASTParser=false` 시 `s.cacheKey(query)` → 자기 자신 재귀 호출 → 즉시 stack overflow
- `cache.CacheKey(query)`로 수정하여 plain FNV 해시 호출

## Test plan
- [x] `go build ./...` 컴파일 정상
- [x] `go vet ./...` 이상 없음

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)