### PR TITLE
feat(deploy): Helm Chart 및 Dockerfile (#80)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+bin/
+coverage.*
+.git/
+docs/
+tests/
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: Build
+FROM golang:1.25-bookworm AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux go build -o /db-proxy ./cmd/db-proxy
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /db-proxy /usr/local/bin/db-proxy
+
+EXPOSE 5432 9090 9091
+ENTRYPOINT ["db-proxy"]
+CMD ["config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME=db-proxy
 BUILD_DIR=bin
 
-.PHONY: build run test test-integration test-coverage bench lint clean docker-up docker-down
+.PHONY: build run test test-integration test-coverage bench lint clean docker-up docker-down docker-build
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/db-proxy
@@ -33,6 +33,9 @@ docker-up:
 
 docker-down:
 	docker-compose down -v
+
+docker-build:
+	docker build -t $(BINARY_NAME):latest .
 
 clean:
 	rm -rf $(BUILD_DIR) coverage.out coverage.html

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ internal/
   admin/admin.go                  # Admin HTTP API
 tests/
   e2e_test.go                     # Docker 기반 E2E 테스트
+Dockerfile                        # Multi-stage 빌드
+deploy/helm/db-proxy/             # Kubernetes Helm Chart
 ```
 
 ## Admin API
@@ -213,6 +215,33 @@ tests/
 - `dbproxy_slow_queries_total` — Slow Query 감지 횟수 (target별)
 - `dbproxy_audit_webhook_sent_total` — Audit Webhook 전송 횟수
 - `dbproxy_audit_webhook_errors_total` — Audit Webhook 실패 횟수
+
+## Kubernetes 배포 (Helm)
+
+### Docker 이미지 빌드
+
+```bash
+make docker-build
+```
+
+### Helm Chart 설치
+
+```bash
+# values.yaml에서 writer/readers 주소를 실제 DB로 수정한 뒤:
+helm install db-proxy deploy/helm/db-proxy/ \
+  --set config.writer.host=primary.db.internal \
+  --set config.backend.password=mypassword
+```
+
+### 주요 values
+
+| 키 | 기본값 | 설명 |
+|---|---|---|
+| `replicaCount` | 2 | 프록시 Pod 수 |
+| `config.*` | (config.yaml 전체) | db-proxy 설정 |
+| `autoscaling.enabled` | false | HPA 활성화 |
+| `podDisruptionBudget.enabled` | true | PDB 활성화 |
+| `serviceMonitor.enabled` | false | Prometheus Operator ServiceMonitor |
 
 ## 라이선스
 

--- a/deploy/helm/db-proxy/Chart.yaml
+++ b/deploy/helm/db-proxy/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: db-proxy
+description: A lightweight PostgreSQL proxy with connection pooling, R/W routing, and query caching
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - postgresql
+  - proxy
+  - connection-pooling
+  - database
+home: https://github.com/jyukki97/db-proxy
+sources:
+  - https://github.com/jyukki97/db-proxy

--- a/deploy/helm/db-proxy/templates/_helpers.tpl
+++ b/deploy/helm/db-proxy/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "db-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "db-proxy.labels" -}}
+helm.sh/chart: {{ include "db-proxy.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "db-proxy.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "db-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "db-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/db-proxy/templates/configmap.yaml
+++ b/deploy/helm/db-proxy/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/deploy/helm/db-proxy/templates/deployment.yaml
+++ b/deploy/helm/db-proxy/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "db-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "db-proxy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - /etc/db-proxy/config.yaml
+          ports:
+            - name: pg
+              containerPort: 5432
+              protocol: TCP
+            {{- if .Values.metricsService.enabled }}
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.adminService.enabled }}
+            - name: admin
+              containerPort: 9091
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: pg
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            {{- if .Values.adminService.enabled }}
+            httpGet:
+              path: /admin/health
+              port: admin
+            {{- else }}
+            tcpSocket:
+              port: pg
+            {{- end }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/db-proxy
+              readOnly: true
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "db-proxy.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/db-proxy/templates/hpa.yaml
+++ b/deploy/helm/db-proxy/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "db-proxy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/db-proxy/templates/pdb.yaml
+++ b/deploy/helm/db-proxy/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "db-proxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/db-proxy/templates/service.yaml
+++ b/deploy/helm/db-proxy/templates/service.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: pg
+      protocol: TCP
+      name: pg
+  selector:
+    {{- include "db-proxy.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.metricsService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "db-proxy.fullname" . }}-metrics
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metricsService.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "db-proxy.selectorLabels" . | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.adminService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "db-proxy.fullname" . }}-admin
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.adminService.port }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
+  selector:
+    {{- include "db-proxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/db-proxy/templates/servicemonitor.yaml
+++ b/deploy/helm/db-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "db-proxy.fullname" . }}
+  labels:
+    {{- include "db-proxy.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "db-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/db-proxy/values.yaml
+++ b/deploy/helm/db-proxy/values.yaml
@@ -1,0 +1,100 @@
+replicaCount: 2
+
+image:
+  repository: db-proxy
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# db-proxy config.yaml contents
+config:
+  proxy:
+    listen: "0.0.0.0:5432"
+  writer:
+    host: "primary.db.internal"
+    port: 5432
+  readers:
+    - host: "replica-1.db.internal"
+      port: 5432
+  pool:
+    min_connections: 5
+    max_connections: 50
+    idle_timeout: "10m"
+    max_lifetime: "1h"
+    connection_timeout: "5s"
+    reset_query: "DISCARD ALL"
+  routing:
+    read_after_write_delay: "500ms"
+    causal_consistency: false
+    ast_parser: false
+  cache:
+    enabled: true
+    cache_ttl: "10s"
+    max_cache_entries: 10000
+    max_result_size: "1MB"
+  firewall:
+    enabled: true
+    block_delete_without_where: true
+    block_update_without_where: true
+    block_drop_table: false
+    block_truncate: false
+  audit:
+    enabled: false
+    slow_query_threshold: "500ms"
+    log_all_queries: false
+  backend:
+    user: "postgres"
+    password: "postgres"
+    database: "testdb"
+  metrics:
+    enabled: true
+    listen: "0.0.0.0:9090"
+  admin:
+    enabled: true
+    listen: "0.0.0.0:9091"
+
+service:
+  type: ClusterIP
+  port: 5432
+
+metricsService:
+  enabled: true
+  port: 9090
+
+adminService:
+  enabled: true
+  port: 9091
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+serviceMonitor:
+  enabled: false
+  interval: 15s
+  labels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -28,7 +28,7 @@
 | W20 | LSN 기반 Causal Consistency | Replication Lag 인지형 라우팅, Writer LSN 트래킹 | 완료 |
 | W21-22 | AST 파서 + 쿼리 방화벽 | pg_query_go AST 파서 도입, 쿼리 방화벽, Semantic Caching | 완료 |
 | W23 | Audit Logging & Slow Query | 쿼리 감사 로그, Slow Query 감지, Webhook 알림 | 진행 중 |
-| W24 | Helm Chart | K8s 배포용 Helm Chart, Dockerfile 최적화 | 미착수 |
+| W24 | Helm Chart | K8s 배포용 Helm Chart, Dockerfile 최적화 | 진행 중 |
 | W25 | Serverless Data API | HTTP REST → PG Protocol 변환, JSON 응답 | 미착수 |
 
 ---


### PR DESCRIPTION
## Summary

- Dockerfile 신규: multi-stage 빌드 (golang:1.25-bookworm → debian:bookworm-slim)
  - cgo 빌드 지원 (pg_query_go), ca-certificates 포함
- Helm Chart (`deploy/helm/db-proxy/`) 신규:
  - Deployment + ConfigMap (config.yaml 전체 주입)
  - Service (PG 5432, Metrics 9090, Admin 9091)
  - HPA (autoscaling.enabled로 제어)
  - PDB (minAvailable: 1)
  - ServiceMonitor (Prometheus Operator 연동)
- Makefile에 `docker-build` 타겟 추가
- README에 Kubernetes 배포 가이드 추가

## Test plan

- [x] `helm lint` 통과 (0 failures)
- [x] `helm template` 유효한 K8s 매니페스트 생성
- [x] ConfigMap에 전체 config.yaml 정상 렌더링
- [x] Deployment에 liveness/readiness probe 설정
- [x] HPA, PDB, ServiceMonitor 조건부 렌더링 확인
- [x] `go build ./...` 통과

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)