### PR TITLE
fix(audit): Webhook 비동기 호출로 Channel Blocking 방지

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -142,7 +142,7 @@ func (l *Logger) handleEvent(e Event) {
 		)
 
 		if l.httpClient != nil {
-			l.sendWebhook(e)
+			go l.sendWebhook(e)
 		}
 	} else if l.cfg.LogAllQueries {
 		e.EventType = "query"

--- a/internal/audit/audit_block_test.go
+++ b/internal/audit/audit_block_test.go
@@ -1,0 +1,57 @@
+package audit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAuditLogger_WebhookDoesNotBlockLogging(t *testing.T) {
+	// Create a mock server that takes 2 seconds to respond
+	var webhookCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookCalls.Add(1)
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cfg := Config{
+		Enabled:            true,
+		SlowQueryThreshold: 10 * time.Millisecond,
+		LogAllQueries:      true,
+		Webhook: WebhookConfig{
+			Enabled: true,
+			URL:     ts.URL,
+			Timeout: 5 * time.Second,
+		},
+	}
+
+	logger := New(cfg)
+	defer logger.Close()
+
+	// Send a slow query that triggers a webhook
+	logger.Log(Event{DurationMS: 100, Query: "SELECT * FROM delay1"})
+
+	// Wait for the processor to pick up the event and fire the webhook goroutine
+	time.Sleep(100 * time.Millisecond)
+
+	// Now send 1100 normal events while the webhook is still in-flight.
+	// With the fix, the processor goroutine is NOT blocked, so it should drain
+	// these events from the channel without dropping them.
+	sent := 1100
+	for i := 0; i < sent; i++ {
+		logger.Log(Event{DurationMS: 5, Query: "SELECT * FROM fast"})
+	}
+
+	// Give the processor time to drain all events (should be fast since no blocking)
+	time.Sleep(500 * time.Millisecond)
+
+	// Check channel is drained — if the processor was blocked, events would pile up
+	remaining := len(logger.eventCh)
+	if remaining > 10 {
+		t.Errorf("Expected channel to be mostly drained, but %d events remain (processor was likely blocked)", remaining)
+	}
+}


### PR DESCRIPTION
## Summary
- `sendWebhook`을 `go l.sendWebhook(e)`로 별도 고루틴 실행하여 워커 블로킹 방지
- 기존: Webhook HTTP 호출(최대 5초) 동안 프로세서 블로킹 → 채널 가득 차면 이벤트 드랍
- 수정: 비동기 호출로 프로세서가 즉시 다음 이벤트 처리 가능

## Test plan
- [x] `TestAuditLogger_WebhookDoesNotBlockLogging` 통과 확인

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)