### PR TITLE
fix(dataapi): drainUntilReady 에러 반환으로 Connection Poisoning 방지

### DIFF
--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -264,7 +264,10 @@ func (s *Server) executeOnPool(ctx context.Context, sql string, p *pool.Pool) (*
 		return resp, nil // return result even if reset fails
 	}
 	// Drain reset response
-	drainUntilReady(conn)
+	if err := drainUntilReady(conn); err != nil {
+		p.Discard(conn)
+		return resp, nil
+	}
 	p.Release(conn)
 	return resp, nil
 }
@@ -326,11 +329,14 @@ func executeQuery(conn net.Conn, sql string) (*QueryResponse, error) {
 	}
 }
 
-func drainUntilReady(conn net.Conn) {
+func drainUntilReady(conn net.Conn) error {
 	for {
 		msg, err := protocol.ReadMessage(conn)
-		if err != nil || msg.Type == protocol.MsgReadyForQuery {
-			return
+		if err != nil {
+			return err
+		}
+		if msg.Type == protocol.MsgReadyForQuery {
+			return nil
 		}
 	}
 }

--- a/internal/dataapi/poison_test.go
+++ b/internal/dataapi/poison_test.go
@@ -1,0 +1,29 @@
+package dataapi
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// brokenConn simulates a connection that fails on Read (e.g., network error during DISCARD ALL).
+type brokenConn struct {
+	net.Conn
+}
+
+func (b *brokenConn) Write(p []byte) (int, error) { return len(p), nil }
+func (b *brokenConn) Read(p []byte) (int, error)  { return 0, net.ErrClosed }
+func (b *brokenConn) SetDeadline(t time.Time) error      { return nil }
+func (b *brokenConn) SetReadDeadline(t time.Time) error  { return nil }
+func (b *brokenConn) SetWriteDeadline(t time.Time) error { return nil }
+func (b *brokenConn) Close() error                       { return nil }
+func (b *brokenConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (b *brokenConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+
+func TestDrainUntilReady_ReturnsErrorOnBrokenConn(t *testing.T) {
+	conn := &brokenConn{}
+	err := drainUntilReady(conn)
+	if err == nil {
+		t.Fatal("expected error from drainUntilReady on broken connection, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- `drainUntilReady`가 `error`를 반환하도록 시그니처 변경
- 에러 발생 시 `p.Release` 대신 `p.Discard`로 죽은 커넥션 폐기
- 기존: DISCARD ALL 중 네트워크 에러 무시 → 죽은 커넥션이 풀에 반납되어 후속 요청 실패
- 수정: 에러 감지 → 커넥션 영구 폐기로 풀 오염 방지

## Test plan
- [x] `TestDrainUntilReady_ReturnsErrorOnBrokenConn` 통과 확인
- [x] `go build ./...` 성공

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)