### PR TITLE
feat(config): 설정 파일 변경 감지 자동 리로드 (fsnotify) (#94)

### DIFF
--- a/cmd/pgmux/main.go
+++ b/cmd/pgmux/main.go
@@ -95,6 +95,25 @@ func run() error {
 		}
 	}()
 
+	// Start config file watcher if enabled
+	if cfg.ConfigOptions.Watch {
+		fw, err := config.NewFileWatcher(cfgPath, func() {
+			slog.Info("config file changed, reloading", "path", cfgPath)
+			if err := reloadConfig(cfgPath, srv); err != nil {
+				slog.Error("config reload failed", "error", err)
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("create config file watcher: %w", err)
+		}
+		defer fw.Stop()
+		go func() {
+			if err := fw.Start(ctx); err != nil {
+				slog.Error("config file watcher error", "error", err)
+			}
+		}()
+	}
+
 	slog.Info("pgmux starting", "listen", cfg.Proxy.Listen)
 
 	return srv.Start(ctx)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jyukki97/pgmux
 go 1.25.1
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/lib/pq v1.11.2
 	github.com/pganalyze/pg_query_go/v5 v5.1.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	Firewall       FirewallConfig       `yaml:"firewall"`
 	Audit          AuditConfig          `yaml:"audit"`
 	DataAPI        DataAPIConfig        `yaml:"data_api"`
+	ConfigOptions  ConfigOptionsConfig  `yaml:"config"`
+}
+
+type ConfigOptionsConfig struct {
+	Watch bool `yaml:"watch"`
 }
 
 type DataAPIConfig struct {

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const debounceInterval = 1 * time.Second
+
+// FileWatcher watches a config file for changes and triggers a callback.
+// It watches the parent directory to handle K8s ConfigMap symlink swaps.
+type FileWatcher struct {
+	path     string
+	fileName string
+	onChange func()
+	watcher  *fsnotify.Watcher
+
+	mu      sync.Mutex
+	stopped bool
+	stopCh  chan struct{}
+}
+
+// NewFileWatcher creates a FileWatcher that monitors the given file path.
+// The onChange callback is invoked (debounced) when the file is modified.
+func NewFileWatcher(path string, onChange func()) (*FileWatcher, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+
+	return &FileWatcher{
+		path:     absPath,
+		fileName: filepath.Base(absPath),
+		onChange: onChange,
+		watcher:  watcher,
+		stopCh:   make(chan struct{}),
+	}, nil
+}
+
+// Start begins watching for file changes. It blocks until the context is
+// cancelled or Stop is called.
+func (fw *FileWatcher) Start(ctx context.Context) error {
+	// Watch the parent directory to catch symlink swaps (K8s ConfigMap).
+	dir := filepath.Dir(fw.path)
+	if err := fw.watcher.Add(dir); err != nil {
+		return fmt.Errorf("watch directory %s: %w", dir, err)
+	}
+
+	slog.Info("config file watcher started", "path", fw.path, "dir", dir)
+
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case <-ctx.Done():
+			fw.cleanup(debounceTimer)
+			return nil
+		case <-fw.stopCh:
+			fw.cleanup(debounceTimer)
+			return nil
+		case event, ok := <-fw.watcher.Events:
+			if !ok {
+				return nil
+			}
+			if !fw.isTargetEvent(event) {
+				continue
+			}
+			slog.Debug("config file event", "op", event.Op, "name", event.Name)
+
+			// Debounce: reset timer on each qualifying event.
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(debounceInterval, fw.onChange)
+
+		case err, ok := <-fw.watcher.Errors:
+			if !ok {
+				return nil
+			}
+			slog.Error("config file watcher error", "error", err)
+		}
+	}
+}
+
+// Stop terminates the file watcher.
+func (fw *FileWatcher) Stop() {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	if fw.stopped {
+		return
+	}
+	fw.stopped = true
+	close(fw.stopCh)
+	fw.watcher.Close()
+}
+
+// isTargetEvent returns true if the event is relevant to the watched file.
+func (fw *FileWatcher) isTargetEvent(event fsnotify.Event) bool {
+	// Only respond to write, create, and rename events.
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+		return false
+	}
+
+	eventBase := filepath.Base(event.Name)
+
+	// Direct match: the config file itself was modified.
+	if eventBase == fw.fileName {
+		return true
+	}
+
+	// K8s ConfigMap symlink swap: when K8s updates a mounted ConfigMap,
+	// it atomically swaps a "..data" symlink. Detect CREATE events on
+	// symlink-like entries (prefixed with "..") in the watched directory.
+	if event.Op&fsnotify.Create != 0 && strings.HasPrefix(eventBase, "..") {
+		return true
+	}
+
+	return false
+}
+
+func (fw *FileWatcher) cleanup(timer *time.Timer) {
+	if timer != nil {
+		timer.Stop()
+	}
+}

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFileWatcher_Modification(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgFile, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	fw, err := NewFileWatcher(cfgFile, func() {
+		called.Add(1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := fw.Start(ctx); err != nil {
+			t.Errorf("Start() error: %v", err)
+		}
+	}()
+
+	// Allow watcher to initialize.
+	time.Sleep(100 * time.Millisecond)
+
+	// Modify the file.
+	if err := os.WriteFile(cfgFile, []byte("modified"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for debounce interval + buffer.
+	time.Sleep(debounceInterval + 500*time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("callback called %d times, want 1", got)
+	}
+
+	fw.Stop()
+}
+
+func TestFileWatcher_Debounce(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgFile, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	fw, err := NewFileWatcher(cfgFile, func() {
+		called.Add(1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := fw.Start(ctx); err != nil {
+			t.Errorf("Start() error: %v", err)
+		}
+	}()
+
+	// Allow watcher to initialize.
+	time.Sleep(100 * time.Millisecond)
+
+	// Rapid modifications within the debounce window.
+	for i := range 5 {
+		if err := os.WriteFile(cfgFile, []byte("change-"+string(rune('0'+i))), 0644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Wait for debounce interval + buffer.
+	time.Sleep(debounceInterval + 500*time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("callback called %d times after rapid changes, want 1", got)
+	}
+
+	fw.Stop()
+}
+
+func TestFileWatcher_SymlinkSwap(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two versions of the config file.
+	v1Dir := filepath.Join(dir, "v1")
+	v2Dir := filepath.Join(dir, "v2")
+	if err := os.Mkdir(v1Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(v2Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v1Dir, "config.yaml"), []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2Dir, "config.yaml"), []byte("v2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a "..data" symlink pointing to v1, like K8s does.
+	dataLink := filepath.Join(dir, "..data")
+	if err := os.Symlink(v1Dir, dataLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create config.yaml symlink -> ..data/config.yaml
+	cfgLink := filepath.Join(dir, "config.yaml")
+	if err := os.Symlink(filepath.Join("..data", "config.yaml"), cfgLink); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	fw, err := NewFileWatcher(cfgLink, func() {
+		called.Add(1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := fw.Start(ctx); err != nil {
+			t.Errorf("Start() error: %v", err)
+		}
+	}()
+
+	// Allow watcher to initialize.
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate K8s ConfigMap swap: atomically replace ..data symlink.
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink(v2Dir, tmpLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmpLink, dataLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for debounce interval + buffer.
+	time.Sleep(debounceInterval + 500*time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("callback called %d times after symlink swap, want 1", got)
+	}
+
+	fw.Stop()
+}
+
+func TestFileWatcher_Stop(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgFile, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	fw, err := NewFileWatcher(cfgFile, func() {
+		called.Add(1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := fw.Start(ctx); err != nil {
+			t.Errorf("Start() error: %v", err)
+		}
+	}()
+
+	// Allow watcher to initialize.
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop should cause Start to return.
+	fw.Stop()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(3 * time.Second):
+		t.Error("Start() did not return after Stop()")
+	}
+
+	// Double Stop should not panic.
+	fw.Stop()
+
+	// Modifications after stop should not trigger callback.
+	if err := os.WriteFile(cfgFile, []byte("after-stop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(debounceInterval + 500*time.Millisecond)
+
+	if got := called.Load(); got != 0 {
+		t.Errorf("callback called %d times after Stop(), want 0", got)
+	}
+}


### PR DESCRIPTION
## 변경 사항

Phase 18: `fsnotify` 기반 설정 파일 변경 감지 자동 리로드 구현

- **`internal/config/watcher.go`** — `FileWatcher` 구현
  - 부모 디렉토리 감시로 K8s ConfigMap symlink swap 지원
  - 1초 디바운싱으로 연속 이벤트 병합
  - `Start(ctx)` / `Stop()` 라이프사이클 관리
- **`internal/config/config.go`** — `ConfigOptionsConfig` 구조체 추가 (`config.watch` 필드)
- **`cmd/pgmux/main.go`** — `config.watch: true` 시 FileWatcher 시작, 기존 `reloadConfig()` 재사용
- **`internal/config/watcher_test.go`** — 단위 테스트 4건
  - 파일 수정 감지
  - 디바운싱 (5회 연속 수정 → 1회 콜백)
  - K8s ConfigMap symlink swap 감지
  - Stop 안전성 (이중 Stop, Stop 후 이벤트 무시)

## 테스트

- `go test ./internal/config/...` — 기존 15건 + 신규 4건 = 전체 19건 통과
- K8s ConfigMap의 atomic symlink swap 시나리오를 테스트에서 재현

closes #94