### PR TITLE
feat(config): make readers optional for writer-only mode (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ writer:
   host: "primary.db.internal"
   port: 5432
 
-readers:
+readers:                              # 선택사항 — 생략 시 모든 쿼리가 writer로 라우팅
   - host: "replica-1.db.internal"
     port: 5432
   - host: "replica-2.db.internal"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,9 +272,6 @@ func (c *Config) validate() error {
 	if c.Writer.Port <= 0 || c.Writer.Port > 65535 {
 		return fmt.Errorf("writer.port must be between 1 and 65535, got %d", c.Writer.Port)
 	}
-	if len(c.Readers) == 0 {
-		return fmt.Errorf("at least one reader is required")
-	}
 	for i, r := range c.Readers {
 		if r.Host == "" {
 			return fmt.Errorf("readers[%d].host is required", i)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -178,9 +178,12 @@ writer:
   host: "primary.db.internal"
   port: 5432
 `
-	_, err := loadFromStringRaw(t, content)
-	if err == nil {
-		t.Error("expected error for no readers")
+	cfg, err := loadFromStringRaw(t, content)
+	if err != nil {
+		t.Fatalf("unexpected error for no readers: %v", err)
+	}
+	if len(cfg.Readers) != 0 {
+		t.Errorf("expected empty readers, got %d", len(cfg.Readers))
 	}
 }
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -193,6 +193,10 @@ func NewServer(cfg *config.Config) *Server {
 			"webhook", cfg.Audit.Webhook.Enabled)
 	}
 
+	if len(readerAddrs) == 0 {
+		slog.Info("no readers configured, all queries routed to writer")
+	}
+
 	slog.Info("server initialized",
 		"writer", writerAddr,
 		"readers", len(readerAddrs),


### PR DESCRIPTION
## Summary

- `readers` 설정을 선택사항으로 변경하여 writer-only 모드 지원
- readers가 비어 있으면 모든 쿼리가 writer로 라우팅됨 (기존 fallback 로직 활용)
- Primary 1대만으로 풀링 + 캐싱 + 방화벽 기능 사용 가능

## Changes

- `internal/config/config.go`: readers 필수 validation 제거
- `internal/config/config_test.go`: 테스트를 readers 비어있어도 정상 로드 확인으로 변경
- `internal/proxy/server.go`: readers 없을 때 안내 로그 추가
- `README.md`: readers 설정에 선택사항 주석 추가

## Test plan

- [x] `go test ./internal/config/ -run TestLoad_Validation` 통과
- [x] `go test ./internal/...` 전체 통과
- [x] `go build ./...` 빌드 성공

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)