### PR TITLE
fix(audit): prevent webhook dedup map memory leak

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,9 +32,10 @@ type Config struct {
 
 // WebhookConfig holds webhook notification configuration.
 type WebhookConfig struct {
-	Enabled bool
-	URL     string
-	Timeout time.Duration
+	Enabled       bool
+	URL           string
+	Timeout       time.Duration
+	DedupInterval time.Duration // dedup window for same query; default 1m
 }
 
 // Logger is the audit logger that handles structured logging and webhook notifications.
@@ -58,11 +59,15 @@ type Logger struct {
 
 // New creates a new AuditLogger. Call Close() when done.
 func New(cfg Config) *Logger {
+	dedupInterval := cfg.Webhook.DedupInterval
+	if dedupInterval == 0 {
+		dedupInterval = time.Minute
+	}
 	l := &Logger{
 		cfg:             cfg,
 		eventCh:         make(chan Event, 1024),
 		lastWebhook:     make(map[string]time.Time),
-		webhookInterval: time.Minute,
+		webhookInterval: dedupInterval,
 		stopCh:          make(chan struct{}),
 	}
 
@@ -76,6 +81,9 @@ func New(cfg Config) *Logger {
 
 	l.wg.Add(1)
 	go l.processEvents()
+
+	l.wg.Add(1)
+	go l.cleanupWebhookDedup()
 
 	return l
 }
@@ -211,6 +219,30 @@ func (l *Logger) sendWebhook(e Event) {
 	l.webhookSent++
 	l.mu.Unlock()
 	slog.Debug("audit webhook sent", "query", truncateQuery(e.Query, 100))
+}
+
+// cleanupWebhookDedup periodically removes expired entries from lastWebhook map
+// to prevent unbounded memory growth.
+func (l *Logger) cleanupWebhookDedup() {
+	defer l.wg.Done()
+	ticker := time.NewTicker(l.webhookInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-ticker.C:
+			l.lastWebhookMu.Lock()
+			now := time.Now()
+			for key, last := range l.lastWebhook {
+				if now.Sub(last) >= l.webhookInterval {
+					delete(l.lastWebhook, key)
+				}
+			}
+			l.lastWebhookMu.Unlock()
+		}
+	}
 }
 
 func truncateQuery(q string, maxLen int) string {

--- a/internal/audit/audit_leak_test.go
+++ b/internal/audit/audit_leak_test.go
@@ -1,0 +1,102 @@
+package audit
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestAuditLogger_WebhookDedupCleanup verifies that the lastWebhook map is
+// periodically cleaned up, preventing unbounded memory growth.
+func TestAuditLogger_WebhookDedupCleanup(t *testing.T) {
+	logger := New(Config{
+		Enabled:            true,
+		SlowQueryThreshold: 1 * time.Millisecond,
+		Webhook: WebhookConfig{
+			Enabled:       true,
+			URL:           "http://localhost:9999",
+			DedupInterval: 500 * time.Millisecond,
+		},
+	})
+	defer logger.Close()
+
+	// Simulate unique slow queries to populate lastWebhook map
+	for i := 0; i < 50; i++ {
+		logger.Log(Event{
+			Timestamp:  time.Now(),
+			EventType:  "query",
+			Query:      fmt.Sprintf("SELECT * FROM table_%d", i),
+			DurationMS: 50.0,
+		})
+	}
+
+	// Wait for events to be processed and sendWebhook goroutines to set map entries
+	time.Sleep(300 * time.Millisecond)
+
+	logger.lastWebhookMu.Lock()
+	afterInsert := len(logger.lastWebhook)
+	logger.lastWebhookMu.Unlock()
+
+	if afterInsert == 0 {
+		t.Fatal("expected lastWebhook map to have entries after logging")
+	}
+	t.Logf("map size after inserts: %d", afterInsert)
+
+	// Wait for entries to expire (500ms dedup interval) + cleanup tick
+	time.Sleep(800 * time.Millisecond)
+
+	logger.lastWebhookMu.Lock()
+	afterCleanup := len(logger.lastWebhook)
+	logger.lastWebhookMu.Unlock()
+
+	t.Logf("map size after cleanup: %d", afterCleanup)
+
+	if afterCleanup >= afterInsert {
+		t.Errorf("cleanup did not reduce map: before=%d, after=%d", afterInsert, afterCleanup)
+	}
+	if afterCleanup != 0 {
+		t.Errorf("expected map to be empty after cleanup, got %d entries", afterCleanup)
+	}
+}
+
+// TestAuditLogger_WebhookDedupBounded verifies that the map stays bounded
+// even under continuous unique query load.
+func TestAuditLogger_WebhookDedupBounded(t *testing.T) {
+	logger := New(Config{
+		Enabled:            true,
+		SlowQueryThreshold: 1 * time.Millisecond,
+		Webhook: WebhookConfig{
+			Enabled:       true,
+			URL:           "http://localhost:9999",
+			DedupInterval: 100 * time.Millisecond,
+		},
+	})
+	defer logger.Close()
+
+	// Send queries in batches with pauses to allow cleanup
+	for batch := 0; batch < 5; batch++ {
+		for i := 0; i < 50; i++ {
+			logger.Log(Event{
+				Timestamp:  time.Now(),
+				EventType:  "query",
+				Query:      fmt.Sprintf("SELECT * FROM batch_%d_table_%d", batch, i),
+				DurationMS: 50.0,
+			})
+		}
+		time.Sleep(200 * time.Millisecond) // let cleanup run between batches
+	}
+
+	// Final cleanup pass
+	time.Sleep(300 * time.Millisecond)
+
+	logger.lastWebhookMu.Lock()
+	finalSize := len(logger.lastWebhook)
+	logger.lastWebhookMu.Unlock()
+
+	t.Logf("final map size: %d (sent 250 unique queries across 5 batches)", finalSize)
+
+	// Without cleanup this would be ~250; with cleanup it should be much smaller
+	if finalSize > 100 {
+		t.Errorf("map size %d exceeds expected bound, cleanup may not be working", finalSize)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #108: `lastWebhook` map in Audit Logger grew without bound, leaking memory for every unique slow query
- Added `cleanupWebhookDedup()` goroutine that periodically evicts expired entries from the dedup map
- Added `DedupInterval` field to `WebhookConfig` for configurability (defaults to 1 minute)
- Cleanup runs on the same interval as the dedup window, removing entries older than the interval

## Test plan
- [x] `TestAuditLogger_WebhookDedupCleanup` — verifies map grows then shrinks to 0 after cleanup
- [x] `TestAuditLogger_WebhookDedupBounded` — verifies map stays bounded under continuous load
- [x] Race detector passes
- [x] All existing audit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)