### PR TITLE
fix(pool): 에러 발생 시 오염된 커넥션이 풀에 반납되는 Protocol Desync 버그 (#111)

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -1190,11 +1190,15 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 	// Relay response and collect bytes for caching
 	if s.queryCache != nil {
 		collected, err := s.relayAndCollect(clientConn, rConn)
-		rPool.Release(rConn)
 		execSpan.End()
 		if err != nil {
+			rPool.Discard(rConn)
+			if cb, ok := s.getReaderCB(readerAddr); ok {
+				cb.RecordFailure()
+			}
 			return fmt.Errorf("relay reader response: %w", err)
 		}
+		rPool.Release(rConn)
 		if collected != nil {
 			// Cache store span
 			_, storeSpan := telemetry.Tracer().Start(traceCtx, "pgmux.cache.store")
@@ -1968,11 +1972,12 @@ func (s *Server) pollReaderLSNs(ctx context.Context) {
 		}
 
 		lsn, err := s.queryReplayLSN(conn)
-		rPool.Release(conn)
 		if err != nil {
-			slog.Debug("LSN poll: query replay LSN failed", "addr", addr, "error", err)
+			rPool.Discard(conn)
+			slog.Debug("LSN poll: query replay LSN failed, discarding connection", "addr", addr, "error", err)
 			continue
 		}
+		rPool.Release(conn)
 
 		s.balancer.SetReplayLSN(addr, lsn)
 


### PR DESCRIPTION
## 변경 사항
- `relayAndCollect` 에러 발생 시 `Release` → `Discard`로 변경하여 오염된 커넥션 즉시 폐기
- `queryReplayLSN` 실패 시에도 `Release` → `Discard`로 변경
- 에러 경로에서 circuit breaker failure 기록 추가

## 테스트
- `go build ./...` 빌드 통과
- 기존 Discard/Release 패턴(`relayUntilReady` 에러 경로 등)과 동일한 방식 적용

closes #111