### PR TITLE
fix(proxy): 클라이언트 핸들러 Panic 시 전체 서버 크래시 (Global Panic Vulnerability) (#112)

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -272,6 +272,14 @@ func (s *Server) Start(ctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic in client handler, connection isolated",
+						"remote", conn.RemoteAddr(),
+						"panic", r,
+					)
+				}
+			}()
 			s.handleConn(ctx, conn)
 		}()
 	}


### PR DESCRIPTION
## 변경 사항
- 클라이언트 핸들링 고루틴에 `defer recover()` 추가
- panic 발생 시 해당 클라이언트 연결만 격리 종료, 서버는 계속 동작
- panic 정보를 `slog.Error`로 기록 (remote addr 포함)

## 테스트
- `go build ./...` 빌드 통과
- `handleConn` 내부에 이미 `defer rawConn.Close()`가 있어 recover 후 커넥션 정리 보장

closes #112