### PR TITLE
fix(admin): use getter methods to prevent dangling pool pointers after reload (#116)

### DIFF
--- a/cmd/pgmux/main.go
+++ b/cmd/pgmux/main.go
@@ -77,7 +77,7 @@ func run() error {
 
 	// Start Admin API server
 	if cfg.Admin.Enabled {
-		adminSrv := admin.New(cfg, srv.Cache(), srv.Invalidator(), srv.WriterPool(), srv.ReaderPools(), srv.AuditLogger())
+		adminSrv := admin.New(srv.Cfg, srv.Cache, srv.Invalidator, srv.WriterPool, srv.ReaderPools, srv.AuditLogger)
 		adminSrv.SetReloadFunc(func() error {
 			return reloadConfig(cfgPath, srv)
 		})
@@ -90,7 +90,7 @@ func run() error {
 
 	// Start Data API server
 	if cfg.DataAPI.Enabled {
-		apiSrv := dataapi.New(cfg, srv.WriterPool(), srv.ReaderPools(), srv.Balancer(), srv.Cache(), srv.ProxyMetrics(), srv.RateLimiter())
+		apiSrv := dataapi.New(srv.Cfg, srv.WriterPool, srv.ReaderPools, srv.Balancer, srv.Cache, srv.ProxyMetrics(), srv.RateLimiter)
 		go func() {
 			if err := apiSrv.ListenAndServe(cfg.DataAPI.Listen); err != nil && err != http.ErrServerClosed {
 				slog.Error("data api server error", "error", err)

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -18,14 +18,14 @@ import (
 
 // Server is the Admin API HTTP server.
 type Server struct {
-	cfg         *config.Config
-	cache       *cache.Cache
-	invalidator *cache.Invalidator
-	writerPool  *pool.Pool
-	readerPools map[string]*pool.Pool
-	auditLogger *audit.Logger
-	reloadFunc  func() error
-	mu          sync.RWMutex
+	cfgFn         func() *config.Config
+	cacheFn       func() *cache.Cache
+	invalidatorFn func() *cache.Invalidator
+	writerPoolFn  func() *pool.Pool
+	readerPoolsFn func() map[string]*pool.Pool
+	auditLoggerFn func() *audit.Logger
+	reloadFunc    func() error
+	mu            sync.RWMutex
 }
 
 // SetReloadFunc sets the function to call when reload is requested.
@@ -34,14 +34,16 @@ func (s *Server) SetReloadFunc(fn func() error) {
 }
 
 // New creates a new Admin server.
-func New(cfg *config.Config, c *cache.Cache, inv *cache.Invalidator, writerPool *pool.Pool, readerPools map[string]*pool.Pool, auditLogger *audit.Logger) *Server {
+// All parameters except reloadFunc are getter functions so that Admin always
+// accesses the latest objects even after a hot-reload.
+func New(cfgFn func() *config.Config, cacheFn func() *cache.Cache, invalidatorFn func() *cache.Invalidator, writerPoolFn func() *pool.Pool, readerPoolsFn func() map[string]*pool.Pool, auditLoggerFn func() *audit.Logger) *Server {
 	return &Server{
-		cfg:         cfg,
-		cache:       c,
-		invalidator: inv,
-		writerPool:  writerPool,
-		readerPools: readerPools,
-		auditLogger: auditLogger,
+		cfgFn:         cfgFn,
+		cacheFn:       cacheFn,
+		invalidatorFn: invalidatorFn,
+		writerPoolFn:  writerPoolFn,
+		readerPoolsFn: readerPoolsFn,
+		auditLoggerFn: auditLoggerFn,
 	}
 }
 
@@ -65,16 +67,18 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.cfgFn()
+
 	type backendHealth struct {
 		Addr    string `json:"addr"`
 		Healthy bool   `json:"healthy"`
 	}
 
-	writerAddr := fmt.Sprintf("%s:%d", s.cfg.Writer.Host, s.cfg.Writer.Port)
+	writerAddr := fmt.Sprintf("%s:%d", cfg.Writer.Host, cfg.Writer.Port)
 	writerHealthy := checkTCP(writerAddr)
 
-	readers := make([]backendHealth, 0, len(s.cfg.Readers))
-	for _, r := range s.cfg.Readers {
+	readers := make([]backendHealth, 0, len(cfg.Readers))
+	for _, r := range cfg.Readers {
 		addr := fmt.Sprintf("%s:%d", r.Host, r.Port)
 		readers = append(readers, backendHealth{
 			Addr:    addr,
@@ -97,12 +101,18 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.cfgFn()
+	writerPool := s.writerPoolFn()
+	readerPools := s.readerPoolsFn()
+	c := s.cacheFn()
+	auditLogger := s.auditLoggerFn()
+
 	poolStats := make(map[string]any)
 
 	// Writer pool stats
-	if s.writerPool != nil {
-		wOpen, wIdle := s.writerPool.Stats()
-		writerAddr := fmt.Sprintf("%s:%d", s.cfg.Writer.Host, s.cfg.Writer.Port)
+	if writerPool != nil {
+		wOpen, wIdle := writerPool.Stats()
+		writerAddr := fmt.Sprintf("%s:%d", cfg.Writer.Host, cfg.Writer.Port)
 		poolStats["writer"] = map[string]any{
 			"addr": writerAddr,
 			"open": wOpen,
@@ -112,7 +122,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 
 	// Reader pool stats
 	readerStats := make(map[string]any)
-	for addr, p := range s.readerPools {
+	for addr, p := range readerPools {
 		open, idle := p.Stats()
 		readerStats[addr] = map[string]any{
 			"open": open,
@@ -122,10 +132,10 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	poolStats["readers"] = readerStats
 
 	cacheStats := map[string]any{
-		"enabled": s.cache != nil,
+		"enabled": c != nil,
 	}
-	if s.cache != nil {
-		cacheStats["entries"] = s.cache.Len()
+	if c != nil {
+		cacheStats["entries"] = c.Len()
 	}
 
 	resp := map[string]any{
@@ -133,8 +143,8 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		"cache": cacheStats,
 	}
 
-	if s.auditLogger != nil {
-		slow, sent, errors := s.auditLogger.Stats()
+	if auditLogger != nil {
+		slow, sent, errors := auditLogger.Stats()
 		resp["audit"] = map[string]any{
 			"slow_queries":   slow,
 			"webhook_sent":   sent,
@@ -151,6 +161,8 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+
+	cfg := s.cfgFn()
 
 	// Create a safe copy with masked passwords
 	type safeAuthUser struct {
@@ -175,24 +187,24 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 			Database string `json:"database"`
 		} `json:"backend"`
 	}{
-		Proxy:   s.cfg.Proxy,
-		Writer:  s.cfg.Writer,
-		Readers: s.cfg.Readers,
-		Pool:    s.cfg.Pool,
-		Routing: s.cfg.Routing,
-		Cache:   s.cfg.Cache,
-		TLS:     s.cfg.TLS,
+		Proxy:   cfg.Proxy,
+		Writer:  cfg.Writer,
+		Readers: cfg.Readers,
+		Pool:    cfg.Pool,
+		Routing: cfg.Routing,
+		Cache:   cfg.Cache,
+		TLS:     cfg.TLS,
 	}
-	safe.Auth.Enabled = s.cfg.Auth.Enabled
-	for _, u := range s.cfg.Auth.Users {
+	safe.Auth.Enabled = cfg.Auth.Enabled
+	for _, u := range cfg.Auth.Users {
 		safe.Auth.Users = append(safe.Auth.Users, safeAuthUser{
 			Username: u.Username,
 			Password: "********",
 		})
 	}
-	safe.Backend.User = s.cfg.Backend.User
+	safe.Backend.User = cfg.Backend.User
 	safe.Backend.Password = "********"
-	safe.Backend.Database = s.cfg.Backend.Database
+	safe.Backend.Database = cfg.Backend.Database
 
 	writeJSON(w, safe)
 }
@@ -204,7 +216,10 @@ func (s *Server) handleCacheFlush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.cache == nil {
+	c := s.cacheFn()
+	inv := s.invalidatorFn()
+
+	if c == nil {
 		writeJSON(w, map[string]string{"status": "cache disabled"})
 		return
 	}
@@ -215,9 +230,9 @@ func (s *Server) handleCacheFlush(w http.ResponseWriter, r *http.Request) {
 
 	if path != "" {
 		// Flush specific table
-		s.cache.InvalidateTable(path)
-		if s.invalidator != nil {
-			s.invalidator.Publish(context.Background(), []string{path})
+		c.InvalidateTable(path)
+		if inv != nil {
+			inv.Publish(context.Background(), []string{path})
 		}
 		slog.Info("admin: cache flushed for table", "table", path)
 		writeJSON(w, map[string]string{"status": "flushed", "table": path})
@@ -225,9 +240,9 @@ func (s *Server) handleCacheFlush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Flush all
-	s.cache.FlushAll()
-	if s.invalidator != nil {
-		s.invalidator.PublishFlushAll(context.Background())
+	c.FlushAll()
+	if inv != nil {
+		inv.PublishFlushAll(context.Background())
 	}
 	slog.Info("admin: full cache flush")
 	writeJSON(w, map[string]string{"status": "flushed"})

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jyukki97/pgmux/internal/audit"
 	"github.com/jyukki97/pgmux/internal/cache"
 	"github.com/jyukki97/pgmux/internal/config"
 	"github.com/jyukki97/pgmux/internal/pool"
 )
 
-func testServer() *Server {
+func testServer() (*Server, *cache.Cache) {
 	cfg := &config.Config{
 		Proxy:  config.ProxyConfig{Listen: "0.0.0.0:5432"},
 		Writer: config.DBConfig{Host: "127.0.0.1", Port: 5432},
@@ -43,12 +44,21 @@ func testServer() *Server {
 		MaxEntries: 1000,
 		TTL:        10 * time.Second,
 	})
+	readerPools := map[string]*pool.Pool{}
 
-	return New(cfg, c, nil, nil, map[string]*pool.Pool{}, nil)
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return c },
+		func() *cache.Invalidator { return nil },
+		func() *pool.Pool { return nil },
+		func() map[string]*pool.Pool { return readerPools },
+		func() *audit.Logger { return nil },
+	)
+	return srv, c
 }
 
 func TestHandleHealth(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	req := httptest.NewRequest(http.MethodGet, "/admin/health", nil)
 	w := httptest.NewRecorder()
 
@@ -70,7 +80,7 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleStats(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	req := httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
 	w := httptest.NewRecorder()
 
@@ -90,7 +100,7 @@ func TestHandleStats(t *testing.T) {
 }
 
 func TestHandleConfig_MasksPassword(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	req := httptest.NewRequest(http.MethodGet, "/admin/config", nil)
 	w := httptest.NewRecorder()
 
@@ -113,14 +123,14 @@ func TestHandleConfig_MasksPassword(t *testing.T) {
 }
 
 func TestHandleCacheFlush(t *testing.T) {
-	srv := testServer()
+	srv, c := testServer()
 
 	// Add some cache entries
-	srv.cache.Set(cache.CacheKey("SELECT 1"), []byte("result1"), []string{"users"})
-	srv.cache.Set(cache.CacheKey("SELECT 2"), []byte("result2"), []string{"orders"})
+	c.Set(cache.CacheKey("SELECT 1"), []byte("result1"), []string{"users"})
+	c.Set(cache.CacheKey("SELECT 2"), []byte("result2"), []string{"orders"})
 
-	if srv.cache.Len() != 2 {
-		t.Fatalf("cache len = %d, want 2", srv.cache.Len())
+	if c.Len() != 2 {
+		t.Fatalf("cache len = %d, want 2", c.Len())
 	}
 
 	// Flush all
@@ -131,16 +141,16 @@ func TestHandleCacheFlush(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", w.Code)
 	}
-	if srv.cache.Len() != 0 {
-		t.Errorf("cache len after flush = %d, want 0", srv.cache.Len())
+	if c.Len() != 0 {
+		t.Errorf("cache len after flush = %d, want 0", c.Len())
 	}
 }
 
 func TestHandleCacheFlush_ByTable(t *testing.T) {
-	srv := testServer()
+	srv, c := testServer()
 
-	srv.cache.Set(cache.CacheKey("SELECT * FROM users"), []byte("r1"), []string{"users"})
-	srv.cache.Set(cache.CacheKey("SELECT * FROM orders"), []byte("r2"), []string{"orders"})
+	c.Set(cache.CacheKey("SELECT * FROM users"), []byte("r1"), []string{"users"})
+	c.Set(cache.CacheKey("SELECT * FROM orders"), []byte("r2"), []string{"orders"})
 
 	// Flush only users table
 	req := httptest.NewRequest(http.MethodPost, "/admin/cache/flush/users", nil)
@@ -151,13 +161,13 @@ func TestHandleCacheFlush_ByTable(t *testing.T) {
 		t.Errorf("status = %d, want 200", w.Code)
 	}
 	// users entry should be gone, orders should remain
-	if srv.cache.Len() != 1 {
-		t.Errorf("cache len after table flush = %d, want 1", srv.cache.Len())
+	if c.Len() != 1 {
+		t.Errorf("cache len after table flush = %d, want 1", c.Len())
 	}
 }
 
 func TestHandleHealth_MethodNotAllowed(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	req := httptest.NewRequest(http.MethodPost, "/admin/health", nil)
 	w := httptest.NewRecorder()
 	srv.handleHealth(w, req)
@@ -168,7 +178,7 @@ func TestHandleHealth_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleReload_Success(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	srv.SetReloadFunc(func() error {
 		return nil
 	})
@@ -189,7 +199,7 @@ func TestHandleReload_Success(t *testing.T) {
 }
 
 func TestHandleReload_Error(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	srv.SetReloadFunc(func() error {
 		return fmt.Errorf("config parse error")
 	})
@@ -213,7 +223,7 @@ func TestHandleReload_Error(t *testing.T) {
 }
 
 func TestHandleReload_NotConfigured(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 	// No reload func set
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/reload", nil)
@@ -226,7 +236,7 @@ func TestHandleReload_NotConfigured(t *testing.T) {
 }
 
 func TestHandleReload_MethodNotAllowed(t *testing.T) {
-	srv := testServer()
+	srv, _ := testServer()
 
 	req := httptest.NewRequest(http.MethodGet, "/admin/reload", nil)
 	w := httptest.NewRecorder()

--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -48,31 +48,34 @@ type ErrorResponse struct {
 
 // Server is the Data API HTTP server.
 type Server struct {
-	cfg         *config.Config
-	writerPool  *pool.Pool
-	readerPools map[string]*pool.Pool
-	balancer    *router.RoundRobin
-	queryCache  *cache.Cache
-	met         *metrics.Metrics
-	rateLimiter *resilience.RateLimiter
-	apiKeys     map[string]bool
+	cfgFn         func() *config.Config
+	writerPoolFn  func() *pool.Pool
+	readerPoolsFn func() map[string]*pool.Pool
+	balancerFn    func() *router.RoundRobin
+	queryCacheFn  func() *cache.Cache
+	met           *metrics.Metrics
+	rateLimiterFn func() *resilience.RateLimiter
+	apiKeys       map[string]bool
 }
 
 // New creates a new Data API server.
-func New(cfg *config.Config, writerPool *pool.Pool, readerPools map[string]*pool.Pool, balancer *router.RoundRobin, queryCache *cache.Cache, met *metrics.Metrics, rateLimiter *resilience.RateLimiter) *Server {
+// Pool, balancer, cache, and rate limiter parameters are getter functions so
+// that Data API always accesses the latest objects even after a hot-reload.
+func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPoolsFn func() map[string]*pool.Pool, balancerFn func() *router.RoundRobin, queryCacheFn func() *cache.Cache, met *metrics.Metrics, rateLimiterFn func() *resilience.RateLimiter) *Server {
+	cfg := cfgFn()
 	keys := make(map[string]bool, len(cfg.DataAPI.APIKeys))
 	for _, k := range cfg.DataAPI.APIKeys {
 		keys[k] = true
 	}
 	return &Server{
-		cfg:         cfg,
-		writerPool:  writerPool,
-		readerPools: readerPools,
-		balancer:    balancer,
-		queryCache:  queryCache,
-		met:         met,
-		rateLimiter: rateLimiter,
-		apiKeys:     keys,
+		cfgFn:         cfgFn,
+		writerPoolFn:  writerPoolFn,
+		readerPoolsFn: readerPoolsFn,
+		balancerFn:    balancerFn,
+		queryCacheFn:  queryCacheFn,
+		met:           met,
+		rateLimiterFn: rateLimiterFn,
+		apiKeys:       keys,
 	}
 }
 
@@ -105,7 +108,8 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rate limit
-	if s.rateLimiter != nil && !s.rateLimiter.Allow() {
+	rateLimiter := s.rateLimiterFn()
+	if rateLimiter != nil && !rateLimiter.Allow() {
 		if s.met != nil {
 			s.met.RateLimited.Inc()
 		}
@@ -133,14 +137,16 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	)
 	defer querySpan.End()
 
+	cfg := s.cfgFn()
+
 	// Firewall check
-	if s.cfg.Firewall.Enabled {
+	if cfg.Firewall.Enabled {
 		fwResult := router.CheckFirewall(req.SQL, router.FirewallConfig{
-			Enabled:                s.cfg.Firewall.Enabled,
-			BlockDeleteWithoutWhere: s.cfg.Firewall.BlockDeleteWithoutWhere,
-			BlockUpdateWithoutWhere: s.cfg.Firewall.BlockUpdateWithoutWhere,
-			BlockDropTable:          s.cfg.Firewall.BlockDropTable,
-			BlockTruncate:           s.cfg.Firewall.BlockTruncate,
+			Enabled:                cfg.Firewall.Enabled,
+			BlockDeleteWithoutWhere: cfg.Firewall.BlockDeleteWithoutWhere,
+			BlockUpdateWithoutWhere: cfg.Firewall.BlockUpdateWithoutWhere,
+			BlockDropTable:          cfg.Firewall.BlockDropTable,
+			BlockTruncate:           cfg.Firewall.BlockTruncate,
 		})
 		if fwResult.Blocked {
 			if s.met != nil {
@@ -200,11 +206,14 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) executeRead(ctx context.Context, sql string) (*QueryResponse, error) {
+	queryCache := s.queryCacheFn()
+	writerPool := s.writerPoolFn()
+
 	// Cache lookup span
 	_, cacheLookupSpan := telemetry.Tracer().Start(ctx, "pgmux.cache.lookup")
-	if s.queryCache != nil {
+	if queryCache != nil {
 		key := s.cacheKey(sql)
-		if cached := s.queryCache.Get(key); cached != nil {
+		if cached := queryCache.Get(key); cached != nil {
 			if s.met != nil {
 				s.met.CacheHits.Inc()
 			}
@@ -223,17 +232,20 @@ func (s *Server) executeRead(ctx context.Context, sql string) (*QueryResponse, e
 	cacheLookupSpan.SetAttributes(attribute.Bool("pgmux.cached", false))
 	cacheLookupSpan.End()
 
+	balancer := s.balancerFn()
+	readerPools := s.readerPoolsFn()
+
 	var readerAddr string
-	if s.balancer != nil {
-		readerAddr = s.balancer.Next()
+	if balancer != nil {
+		readerAddr = balancer.Next()
 	}
 	if readerAddr == "" {
-		return s.executeOnPool(ctx, sql, s.writerPool)
+		return s.executeOnPool(ctx, sql, writerPool)
 	}
 
-	rPool, ok := s.readerPools[readerAddr]
+	rPool, ok := readerPools[readerAddr]
 	if !ok {
-		return s.executeOnPool(ctx, sql, s.writerPool)
+		return s.executeOnPool(ctx, sql, writerPool)
 	}
 
 	resp, err := s.executeOnPool(ctx, sql, rPool)
@@ -242,18 +254,18 @@ func (s *Server) executeRead(ctx context.Context, sql string) (*QueryResponse, e
 		if s.met != nil {
 			s.met.ReaderFallback.Inc()
 		}
-		return s.executeOnPool(ctx, sql, s.writerPool)
+		return s.executeOnPool(ctx, sql, writerPool)
 	}
 
 	// Cache store span
-	if s.queryCache != nil && resp != nil {
+	if queryCache != nil && resp != nil {
 		_, storeSpan := telemetry.Tracer().Start(ctx, "pgmux.cache.store")
 		key := s.cacheKey(sql)
 		if data, err := json.Marshal(resp); err == nil {
 			tables := s.extractTables(sql)
-			s.queryCache.Set(key, data, tables)
+			queryCache.Set(key, data, tables)
 			if s.met != nil {
-				s.met.CacheEntries.Set(float64(s.queryCache.Len()))
+				s.met.CacheEntries.Set(float64(queryCache.Len()))
 			}
 		}
 		storeSpan.End()
@@ -263,19 +275,21 @@ func (s *Server) executeRead(ctx context.Context, sql string) (*QueryResponse, e
 }
 
 func (s *Server) executeWrite(ctx context.Context, sql string) (*QueryResponse, error) {
-	resp, err := s.executeOnPool(ctx, sql, s.writerPool)
+	writerPool := s.writerPoolFn()
+	resp, err := s.executeOnPool(ctx, sql, writerPool)
 	if err != nil {
 		return nil, err
 	}
 
 	// Invalidate cache
-	if s.queryCache != nil {
+	queryCache := s.queryCacheFn()
+	if queryCache != nil {
 		tables := s.extractTables(sql)
 		for _, table := range tables {
-			s.queryCache.InvalidateTable(table)
+			queryCache.InvalidateTable(table)
 			if s.met != nil {
 				s.met.CacheInvalidations.Inc()
-				s.met.CacheEntries.Set(float64(s.queryCache.Len()))
+				s.met.CacheEntries.Set(float64(queryCache.Len()))
 			}
 		}
 	}
@@ -310,7 +324,7 @@ func (s *Server) executeOnPool(ctx context.Context, sql string, p *pool.Pool) (*
 	execSpan.End()
 
 	// Reset session state before returning to pool
-	resetPayload := append([]byte(s.cfg.Pool.ResetQuery), 0)
+	resetPayload := append([]byte(s.cfgFn().Pool.ResetQuery), 0)
 	if err := protocol.WriteMessage(conn, protocol.MsgQuery, resetPayload); err != nil {
 		p.Discard(conn)
 		return resp, nil // return result even if reset fails
@@ -566,21 +580,21 @@ func oidToTypeName(oid uint32) string {
 }
 
 func (s *Server) classifyQuery(sql string) router.QueryType {
-	if s.cfg.Routing.ASTParser {
+	if s.cfgFn().Routing.ASTParser {
 		return router.ClassifyAST(sql)
 	}
 	return router.Classify(sql)
 }
 
 func (s *Server) cacheKey(sql string) uint64 {
-	if s.cfg.Routing.ASTParser {
+	if s.cfgFn().Routing.ASTParser {
 		return cache.SemanticCacheKey(sql)
 	}
 	return cache.CacheKey(sql)
 }
 
 func (s *Server) extractTables(sql string) []string {
-	if s.cfg.Routing.ASTParser {
+	if s.cfgFn().Routing.ASTParser {
 		return router.ExtractTablesAST(sql)
 	}
 	return router.ExtractTables(sql)

--- a/internal/dataapi/handler_test.go
+++ b/internal/dataapi/handler_test.go
@@ -8,7 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jyukki97/pgmux/internal/cache"
 	"github.com/jyukki97/pgmux/internal/config"
+	"github.com/jyukki97/pgmux/internal/pool"
+	"github.com/jyukki97/pgmux/internal/resilience"
+	"github.com/jyukki97/pgmux/internal/router"
 )
 
 func testServer() *Server {
@@ -20,8 +24,20 @@ func testServer() *Server {
 			APIKeys: []string{"test-key-1", "test-key-2"},
 		},
 	}
-	return New(cfg, nil, nil, nil, nil, nil, nil)
+	return New(
+		func() *config.Config { return cfg },
+		nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter,
+	)
 }
+
+// Helper nil-returning getter functions for tests.
+var (
+	nilPool        = func() *pool.Pool { return nil }
+	nilPools       = func() map[string]*pool.Pool { return nil }
+	nilBalancer    = func() *router.RoundRobin { return nil }
+	nilCache       = func() *cache.Cache { return nil }
+	nilRateLimiter = func() *resilience.RateLimiter { return nil }
+)
 
 func TestAuthRequired(t *testing.T) {
 	srv := testServer()
@@ -89,7 +105,7 @@ func TestEmptySQL(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	srv := New(cfg, nil, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
 
 	body := `{"sql": ""}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))
@@ -106,7 +122,7 @@ func TestInvalidBody(t *testing.T) {
 		Pool:    config.PoolConfig{ResetQuery: "DISCARD ALL"},
 		DataAPI: config.DataAPIConfig{Enabled: true},
 	}
-	srv := New(cfg, nil, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
 
 	body := `not json`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))
@@ -128,7 +144,7 @@ func TestFirewallBlock(t *testing.T) {
 		Routing: config.RoutingConfig{ASTParser: true},
 		DataAPI: config.DataAPIConfig{Enabled: true},
 	}
-	srv := New(cfg, nil, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
 
 	body := `{"sql": "DELETE FROM users"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))


### PR DESCRIPTION
## 변경 사항

- Admin API(`internal/admin/admin.go`)와 Data API(`internal/dataapi/handler.go`)의 Server 구조체에서 직접 포인터 필드를 **getter 함수**(`func() *T`)로 교체
- `cmd/pgmux/main.go`에서 `admin.New()`, `dataapi.New()` 호출 시 `srv.WriterPool()` (값 호출) 대신 `srv.WriterPool` (메서드 참조)를 전달하여 항상 최신 객체 접근
- hot-reload(`srv.Reload()`) 이후에도 Admin/DataAPI가 교체된 pool, cache, balancer 등의 최신 참조를 사용하도록 보장
- 기존 테스트(`admin_test.go`, `handler_test.go`) getter 함수 방식에 맞춰 업데이트

## 테스트

- [x] `go build ./...` 빌드 성공
- [x] `go test ./internal/admin/` 전체 통과 (10/10)
- [x] `go test ./internal/dataapi/` 전체 통과 (16/16)
- [x] `go test ./...` 전체 패키지 통과

closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)