### PR TITLE
fix(router): add RLock to prevent data race in balancer hot-reload (#121)

### DIFF
--- a/internal/router/balancer.go
+++ b/internal/router/balancer.go
@@ -54,7 +54,11 @@ func (r *RoundRobin) Next() string {
 
 // MarkUnhealthy marks a backend as unhealthy.
 func (r *RoundRobin) MarkUnhealthy(addr string) {
-	for _, b := range r.backends {
+	r.mu.RLock()
+	backends := r.backends
+	r.mu.RUnlock()
+
+	for _, b := range backends {
 		if b.Addr == addr {
 			b.healthy.Store(false)
 			slog.Warn("backend marked unhealthy", "addr", addr)
@@ -81,7 +85,11 @@ func (r *RoundRobin) StartHealthCheck(ctx context.Context, interval time.Duratio
 }
 
 func (r *RoundRobin) checkBackends() {
-	for _, b := range r.backends {
+	r.mu.RLock()
+	backends := r.backends
+	r.mu.RUnlock()
+
+	for _, b := range backends {
 		if !b.healthy.Load() {
 			conn, err := net.DialTimeout("tcp", b.Addr, 2*time.Second)
 			if err == nil {
@@ -170,8 +178,12 @@ func (r *RoundRobin) Backends() []string {
 
 // HealthyCount returns the number of healthy backends.
 func (r *RoundRobin) HealthyCount() int {
+	r.mu.RLock()
+	backends := r.backends
+	r.mu.RUnlock()
+
 	count := 0
-	for _, b := range r.backends {
+	for _, b := range backends {
 		if b.healthy.Load() {
 			count++
 		}

--- a/internal/router/balancer_test.go
+++ b/internal/router/balancer_test.go
@@ -162,6 +162,45 @@ func TestRoundRobin_Backends(t *testing.T) {
 	}
 }
 
+func TestRoundRobin_ConcurrentUpdateAndRead(t *testing.T) {
+	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// Concurrent UpdateBackends
+	go func() {
+		for i := 0; ctx.Err() == nil; i++ {
+			rb.UpdateBackends([]string{"x:1", "y:2"})
+			rb.UpdateBackends([]string{"a:1", "b:2", "c:3"})
+		}
+	}()
+
+	// Concurrent reads: Next, MarkUnhealthy, HealthyCount, checkBackends
+	go func() {
+		for ctx.Err() == nil {
+			rb.Next()
+		}
+	}()
+	go func() {
+		for ctx.Err() == nil {
+			rb.MarkUnhealthy("a:1")
+		}
+	}()
+	go func() {
+		for ctx.Err() == nil {
+			rb.HealthyCount()
+		}
+	}()
+	go func() {
+		for ctx.Err() == nil {
+			rb.checkBackends()
+		}
+	}()
+
+	<-ctx.Done()
+}
+
 func TestRoundRobin_Recovery(t *testing.T) {
 	// Start a real TCP server to simulate recovery
 	ln, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## 변경 사항
- `MarkUnhealthy()`, `checkBackends()`, `HealthyCount()`에 `mu.RLock()` 추가
- `Next()`/`NextWithLSN()`과 동일한 local snapshot 패턴 적용
- 동시성 재현 테스트 `TestRoundRobin_ConcurrentUpdateAndRead` 추가

## 테스트
- `go test -race ./internal/router/` 전체 PASS
- 새 테스트가 UpdateBackends + MarkUnhealthy/HealthyCount/checkBackends 동시 접근을 500ms간 반복 검증

closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)