### PR TITLE
fix(proxy): add graceful shutdown timeout to prevent infinite hang (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ psql -h 127.0.0.1 -p 5432 -U postgres -d testdb
 ```yaml
 proxy:
   listen: "0.0.0.0:5432"
+  shutdown_timeout: 30s              # Graceful shutdown 타임아웃 (기본: 30s)
 
 writer:
   host: "primary.db.internal"

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -158,6 +158,7 @@ AST 분석으로 위험한 쿼리를 프록시 단에서 사전 차단한다.
 ```yaml
 proxy:
   listen: "0.0.0.0:5432"
+  shutdown_timeout: 30s              # Graceful shutdown 타임아웃 (기본: 30s)
 
 writer:
   host: "primary.db.internal"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,7 +115,8 @@ type BackendConfig struct {
 }
 
 type ProxyConfig struct {
-	Listen string `yaml:"listen"`
+	Listen          string        `yaml:"listen"`
+	ShutdownTimeout time.Duration `yaml:"shutdown_timeout"`
 }
 
 type DBConfig struct {
@@ -176,6 +177,9 @@ func Load(path string) (*Config, error) {
 func (c *Config) applyDefaults() {
 	if c.Proxy.Listen == "" {
 		c.Proxy.Listen = "0.0.0.0:5432"
+	}
+	if c.Proxy.ShutdownTimeout == 0 {
+		c.Proxy.ShutdownTimeout = 30 * time.Second
 	}
 	if c.Pool.MinConnections == 0 {
 		c.Pool.MinConnections = 2

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -244,7 +244,19 @@ func (s *Server) Start(ctx context.Context) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				s.wg.Wait()
+				timeout := s.getConfig().Proxy.ShutdownTimeout
+				done := make(chan struct{})
+				go func() {
+					s.wg.Wait()
+					close(done)
+				}()
+				select {
+				case <-done:
+					slog.Info("all client connections drained")
+				case <-time.After(timeout):
+					slog.Warn("graceful shutdown timed out, forcing exit",
+						"timeout", timeout)
+				}
 				s.closePools()
 				if s.invalidator != nil {
 					s.invalidator.Close()
@@ -252,7 +264,7 @@ func (s *Server) Start(ctx context.Context) error {
 				if s.auditLogger != nil {
 					s.auditLogger.Close()
 				}
-				slog.Info("proxy shut down gracefully")
+				slog.Info("proxy shut down")
 				return nil
 			default:
 				slog.Error("accept connection", "error", err)


### PR DESCRIPTION
## 변경 사항
- `s.wg.Wait()`을 goroutine으로 감싸고 `time.After` select로 강제 종료 타이머 추가
- `proxy.shutdown_timeout` 설정 항목 추가 (기본값: 30s)
- README.md, docs/spec.md YAML 예시에 설정 반영

## 테스트
- `go build ./...` 빌드 성공
- `go test ./internal/config/` 전체 PASS
- 기본값 30초로 설정되어 미설정 시에도 안전하게 동작

closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)