### PR TITLE
fix(proxy): handle PostgreSQL CancelRequest protocol (#123)

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -9,10 +9,17 @@ import (
 	"time"
 )
 
+// BackendKeyHolder is implemented by connections that carry PostgreSQL BackendKeyData.
+type BackendKeyHolder interface {
+	BackendKey() (pid, secret uint32)
+}
+
 type Conn struct {
 	net.Conn
-	CreatedAt  time.Time
-	LastUsedAt time.Time
+	CreatedAt     time.Time
+	LastUsedAt    time.Time
+	BackendPID    uint32
+	BackendSecret uint32
 }
 
 func (c *Conn) expired(maxLifetime time.Duration) bool {
@@ -198,11 +205,15 @@ func (p *Pool) newConn() (*Conn, error) {
 		return nil, fmt.Errorf("dial %s: %w", p.cfg.Addr, err)
 	}
 	now := time.Now()
-	return &Conn{
+	c := &Conn{
 		Conn:       netConn,
 		CreatedAt:  now,
 		LastUsedAt: now,
-	}, nil
+	}
+	if bk, ok := netConn.(BackendKeyHolder); ok {
+		c.BackendPID, c.BackendSecret = bk.BackendKey()
+	}
+	return c, nil
 }
 
 // Ping checks if a connection is still alive.

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -41,6 +41,10 @@ const (
 // SSLRequestCode is the magic number for SSL negotiation
 const SSLRequestCode = 80877103
 
+// CancelRequestCode is the magic number for query cancellation.
+// Clients send this on a new TCP connection to cancel a running query.
+const CancelRequestCode = 80877102
+
 // MaxMessageSize is the maximum allowed payload size for a single PG message (16 MB).
 // Prevents OOM from malicious length headers.
 const MaxMessageSize = 16 * 1024 * 1024

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -12,11 +12,23 @@ import (
 
 // relayAuth relays the full bidirectional authentication flow between client and backend.
 // Backend sends auth challenges → proxy forwards to client → client responds → proxy forwards to backend.
-func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
+// The backend's BackendKeyData is replaced with the proxy's cancel key.
+func (s *Server) relayAuth(clientConn, backendConn net.Conn, proxyPID, proxySecret uint32) error {
 	for {
 		msg, err := protocol.ReadMessage(backendConn)
 		if err != nil {
 			return fmt.Errorf("read backend auth message: %w", err)
+		}
+
+		// Replace backend's BackendKeyData with proxy's cancel key
+		if msg.Type == protocol.MsgBackendKeyData {
+			bkd := make([]byte, 8)
+			binary.BigEndian.PutUint32(bkd[0:4], proxyPID)
+			binary.BigEndian.PutUint32(bkd[4:8], proxySecret)
+			if err := protocol.WriteMessage(clientConn, protocol.MsgBackendKeyData, bkd); err != nil {
+				return fmt.Errorf("send proxy backend key data: %w", err)
+			}
+			continue
 		}
 
 		if err := protocol.WriteMessage(clientConn, msg.Type, msg.Payload); err != nil {
@@ -49,7 +61,8 @@ func (s *Server) relayAuth(clientConn, backendConn net.Conn) error {
 
 // frontendAuth authenticates the client directly at the proxy using MD5 auth.
 // If the user is not in the configured auth.users list, returns an error.
-func (s *Server) frontendAuth(clientConn net.Conn, username string) error {
+// Sends the proxy's BackendKeyData to the client after authentication.
+func (s *Server) frontendAuth(clientConn net.Conn, username string, proxyPID, proxySecret uint32) error {
 	// Look up user in config
 	cfg := s.getConfig()
 	var password string
@@ -102,6 +115,14 @@ func (s *Server) frontendAuth(clientConn net.Conn, username string) error {
 	binary.BigEndian.PutUint32(okPayload[0:4], 0)
 	if err := protocol.WriteMessage(clientConn, protocol.MsgAuthentication, okPayload); err != nil {
 		return fmt.Errorf("send auth ok: %w", err)
+	}
+
+	// Send BackendKeyData with proxy's cancel key
+	bkd := make([]byte, 8)
+	binary.BigEndian.PutUint32(bkd[0:4], proxyPID)
+	binary.BigEndian.PutUint32(bkd[4:8], proxySecret)
+	if err := protocol.WriteMessage(clientConn, protocol.MsgBackendKeyData, bkd); err != nil {
+		return fmt.Errorf("send backend key data: %w", err)
 	}
 
 	// Send ReadyForQuery ('Z', status='I' for idle)

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -77,7 +77,7 @@ func (s *Server) resetConn(conn net.Conn) error {
 }
 
 // fallbackToWriter acquires a writer connection from the pool and forwards the query.
-func (s *Server) fallbackToWriter(ctx context.Context, clientConn net.Conn, msg *protocol.Message) error {
+func (s *Server) fallbackToWriter(ctx context.Context, clientConn net.Conn, msg *protocol.Message, ct *cancelTarget) error {
 	wConn, err := s.writerPool.Acquire(ctx)
 	if err != nil {
 		s.sendError(clientConn, "no available backend connections")
@@ -86,7 +86,9 @@ func (s *Server) fallbackToWriter(ctx context.Context, clientConn net.Conn, msg 
 	if s.metrics != nil {
 		s.metrics.PoolAcquires.WithLabelValues("writer", s.writerAddr).Inc()
 	}
+	ct.setFromConn(s.writerAddr, wConn)
 	err = s.forwardAndRelay(clientConn, wConn, msg)
+	ct.clear()
 	s.resetAndReleaseWriter(wConn)
 	return err
 }

--- a/internal/proxy/cancel.go
+++ b/internal/proxy/cancel.go
@@ -1,0 +1,123 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/jyukki97/pgmux/internal/pool"
+	"github.com/jyukki97/pgmux/internal/protocol"
+)
+
+// cancelTarget tracks the current backend connection for a client session,
+// enabling cancel request forwarding.
+type cancelTarget struct {
+	proxyPID    uint32
+	proxySecret uint32
+
+	mu            sync.Mutex
+	backendAddr   string
+	backendPID    uint32
+	backendSecret uint32
+}
+
+func (ct *cancelTarget) setFromConn(addr string, c *pool.Conn) {
+	ct.mu.Lock()
+	ct.backendAddr = addr
+	ct.backendPID = c.BackendPID
+	ct.backendSecret = c.BackendSecret
+	ct.mu.Unlock()
+}
+
+func (ct *cancelTarget) clear() {
+	ct.mu.Lock()
+	ct.backendAddr = ""
+	ct.backendPID = 0
+	ct.backendSecret = 0
+	ct.mu.Unlock()
+}
+
+func (ct *cancelTarget) get() (addr string, pid, secret uint32) {
+	ct.mu.Lock()
+	addr, pid, secret = ct.backendAddr, ct.backendPID, ct.backendSecret
+	ct.mu.Unlock()
+	return
+}
+
+// cancelKeyPair is the lookup key for the cancel map.
+type cancelKeyPair struct {
+	pid    uint32
+	secret uint32
+}
+
+// newCancelTarget creates a new cancel target with a unique proxy PID and random secret.
+func (s *Server) newCancelTarget() *cancelTarget {
+	pid := s.nextProxyPID.Add(1)
+	var secretBuf [4]byte
+	rand.Read(secretBuf[:])
+	secret := binary.BigEndian.Uint32(secretBuf[:])
+
+	ct := &cancelTarget{
+		proxyPID:    pid,
+		proxySecret: secret,
+	}
+	s.cancelMap.Store(cancelKeyPair{pid: pid, secret: secret}, ct)
+	return ct
+}
+
+// removeCancelTarget removes the cancel target from the map.
+func (s *Server) removeCancelTarget(ct *cancelTarget) {
+	s.cancelMap.Delete(cancelKeyPair{pid: ct.proxyPID, secret: ct.proxySecret})
+}
+
+// handleCancelRequest processes a PostgreSQL CancelRequest.
+func (s *Server) handleCancelRequest(payload []byte) {
+	if len(payload) < 12 {
+		slog.Warn("cancel request: payload too short")
+		return
+	}
+	pid := binary.BigEndian.Uint32(payload[4:8])
+	secret := binary.BigEndian.Uint32(payload[8:12])
+
+	key := cancelKeyPair{pid: pid, secret: secret}
+	val, ok := s.cancelMap.Load(key)
+	if !ok {
+		slog.Debug("cancel request: no matching session", "pid", pid)
+		return
+	}
+
+	ct := val.(*cancelTarget)
+	addr, bPID, bSecret := ct.get()
+	if addr == "" || bPID == 0 {
+		slog.Debug("cancel request: no active backend query", "pid", pid)
+		return
+	}
+
+	slog.Info("forwarding cancel request",
+		"proxy_pid", pid, "backend_addr", addr, "backend_pid", bPID)
+	if err := forwardCancel(addr, bPID, bSecret); err != nil {
+		slog.Warn("cancel request forward failed", "error", err)
+	}
+}
+
+// forwardCancel sends a CancelRequest to the specified backend.
+func forwardCancel(addr string, pid, secret uint32) error {
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial %s for cancel: %w", addr, err)
+	}
+	defer conn.Close()
+
+	var buf [16]byte
+	binary.BigEndian.PutUint32(buf[0:4], 16) // length
+	binary.BigEndian.PutUint32(buf[4:8], protocol.CancelRequestCode)
+	binary.BigEndian.PutUint32(buf[8:12], pid)
+	binary.BigEndian.PutUint32(buf[12:16], secret)
+
+	_, err = conn.Write(buf[:])
+	return err
+}

--- a/internal/proxy/cancel_test.go
+++ b/internal/proxy/cancel_test.go
@@ -1,0 +1,163 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jyukki97/pgmux/internal/pool"
+	"github.com/jyukki97/pgmux/internal/protocol"
+)
+
+func TestCancelTarget_SetAndGet(t *testing.T) {
+	ct := &cancelTarget{proxyPID: 1, proxySecret: 100}
+
+	// Initially empty
+	addr, pid, secret := ct.get()
+	if addr != "" || pid != 0 || secret != 0 {
+		t.Errorf("expected empty, got addr=%q pid=%d secret=%d", addr, pid, secret)
+	}
+
+	// Set from a mock pool.Conn
+	mockConn := &pool.Conn{
+		Conn:          nil, // not needed for this test
+		BackendPID:    42,
+		BackendSecret: 99,
+	}
+	ct.setFromConn("127.0.0.1:5432", mockConn)
+
+	addr, pid, secret = ct.get()
+	if addr != "127.0.0.1:5432" || pid != 42 || secret != 99 {
+		t.Errorf("after set: addr=%q pid=%d secret=%d", addr, pid, secret)
+	}
+
+	// Clear
+	ct.clear()
+	addr, pid, secret = ct.get()
+	if addr != "" || pid != 0 || secret != 0 {
+		t.Errorf("after clear: addr=%q pid=%d secret=%d", addr, pid, secret)
+	}
+}
+
+func TestServer_CancelKeyRegistration(t *testing.T) {
+	s := &Server{}
+
+	ct := s.newCancelTarget()
+	if ct.proxyPID == 0 {
+		t.Error("proxy PID should be non-zero")
+	}
+
+	// Should be findable in the map
+	key := cancelKeyPair{pid: ct.proxyPID, secret: ct.proxySecret}
+	val, ok := s.cancelMap.Load(key)
+	if !ok {
+		t.Fatal("cancel target not found in map")
+	}
+	if val.(*cancelTarget) != ct {
+		t.Error("cancel target mismatch")
+	}
+
+	// Remove
+	s.removeCancelTarget(ct)
+	_, ok = s.cancelMap.Load(key)
+	if ok {
+		t.Error("cancel target should be removed")
+	}
+}
+
+func TestServer_CancelRequestForwarding(t *testing.T) {
+	// Start a mock "backend" that accepts cancel requests
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var receivedPID, receivedSecret uint32
+	var received atomic.Bool
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read cancel request: 16 bytes
+		var buf [16]byte
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, err = conn.Read(buf[:])
+		if err != nil {
+			return
+		}
+		code := binary.BigEndian.Uint32(buf[4:8])
+		if code == protocol.CancelRequestCode {
+			receivedPID = binary.BigEndian.Uint32(buf[8:12])
+			receivedSecret = binary.BigEndian.Uint32(buf[12:16])
+			received.Store(true)
+		}
+	}()
+
+	// Forward a cancel request
+	err = forwardCancel(ln.Addr().String(), 123, 456)
+	if err != nil {
+		t.Fatalf("forwardCancel: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if !received.Load() {
+		t.Fatal("backend did not receive cancel request")
+	}
+	if receivedPID != 123 || receivedSecret != 456 {
+		t.Errorf("got pid=%d secret=%d, want 123/456", receivedPID, receivedSecret)
+	}
+}
+
+func TestServer_HandleCancelRequest_Integration(t *testing.T) {
+	// Start a mock backend
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var received atomic.Bool
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var buf [16]byte
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		conn.Read(buf[:])
+		received.Store(true)
+	}()
+
+	s := &Server{}
+
+	// Register a cancel target with an active backend query
+	ct := s.newCancelTarget()
+	ct.mu.Lock()
+	ct.backendAddr = ln.Addr().String()
+	ct.backendPID = 42
+	ct.backendSecret = 99
+	ct.mu.Unlock()
+
+	// Build cancel request payload (as it would come from ReadStartupMessage)
+	payload := make([]byte, 12)
+	binary.BigEndian.PutUint32(payload[0:4], protocol.CancelRequestCode)
+	binary.BigEndian.PutUint32(payload[4:8], ct.proxyPID)
+	binary.BigEndian.PutUint32(payload[8:12], ct.proxySecret)
+
+	s.handleCancelRequest(payload)
+
+	time.Sleep(200 * time.Millisecond)
+
+	if !received.Load() {
+		t.Error("cancel request was not forwarded to backend")
+	}
+
+	s.removeCancelTarget(ct)
+}

--- a/internal/proxy/pgconn.go
+++ b/internal/proxy/pgconn.go
@@ -16,8 +16,20 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
+// backendKeyConn wraps a net.Conn with captured PostgreSQL BackendKeyData.
+type backendKeyConn struct {
+	net.Conn
+	pid       uint32
+	secretKey uint32
+}
+
+func (c *backendKeyConn) BackendKey() (uint32, uint32) {
+	return c.pid, c.secretKey
+}
+
 // pgConnect establishes an authenticated PostgreSQL connection.
 // Supports MD5 and SCRAM-SHA-256 authentication.
+// Returns a backendKeyConn that carries the backend's PID and secret key.
 func pgConnect(addr, user, password, database string) (net.Conn, error) {
 	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
 	if err != nil {
@@ -35,6 +47,7 @@ func pgConnect(addr, user, password, database string) (net.Conn, error) {
 	}
 
 	// Handle authentication flow
+	var backendPID, backendSecret uint32
 	for {
 		msg, err := protocol.ReadMessage(conn)
 		if err != nil {
@@ -83,11 +96,17 @@ func pgConnect(addr, user, password, database string) (net.Conn, error) {
 			conn.Close()
 			return nil, fmt.Errorf("backend auth error")
 
+		case protocol.MsgBackendKeyData:
+			if len(msg.Payload) >= 8 {
+				backendPID = binary.BigEndian.Uint32(msg.Payload[0:4])
+				backendSecret = binary.BigEndian.Uint32(msg.Payload[4:8])
+			}
+
 		case protocol.MsgReadyForQuery:
-			return conn, nil
+			return &backendKeyConn{Conn: conn, pid: backendPID, secretKey: backendSecret}, nil
 
 		default:
-			// Skip ParameterStatus, BackendKeyData, etc.
+			// Skip ParameterStatus, etc.
 		}
 	}
 }

--- a/internal/proxy/query.go
+++ b/internal/proxy/query.go
@@ -20,7 +20,7 @@ import (
 
 // relayQueries handles the main query loop with transaction-level connection pooling.
 // Writer connections are acquired from writerPool per query/transaction and released back.
-func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session *router.Session) {
+func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session *router.Session, ct *cancelTarget) {
 	// boundWriter is non-nil when a transaction is in progress.
 	// The connection stays bound from BEGIN until COMMIT/ROLLBACK.
 	var boundWriter *pool.Conn
@@ -159,7 +159,9 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				_, execSpan := telemetry.Tracer().Start(queryCtx, "pgmux.backend.exec",
 					trace.WithAttributes(attribute.String("pgmux.route", "writer")),
 				)
+				ct.setFromConn(s.writerAddr, wConn)
 				s.handleWriteQuery(clientConn, wConn, msg, query, session)
+				ct.clear()
 				execSpan.End()
 
 				// Transaction lifecycle management
@@ -177,7 +179,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				}
 				// If !acquired && still in transaction → keep using boundWriter
 			} else {
-				if err := s.handleReadQueryTraced(queryCtx, ctx, clientConn, msg, query, session); err != nil {
+				if err := s.handleReadQueryTraced(queryCtx, ctx, clientConn, msg, query, session, ct); err != nil {
 					querySpan.SetStatus(codes.Error, err.Error())
 					querySpan.End()
 					slog.Error("handle read query", "error", err)
@@ -296,7 +298,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 		case protocol.MsgDescribe:
 			if multiplexMode {
 				// In multiplex mode, handle Describe by forwarding to backend
-				if err := s.handleMultiplexDescribe(ctx, clientConn, msg, synth, boundWriter); err != nil {
+				if err := s.handleMultiplexDescribe(ctx, clientConn, msg, synth, boundWriter, ct); err != nil {
 					slog.Error("multiplex describe", "error", err)
 					return
 				}
@@ -348,7 +350,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				slog.Debug("synthesized query", "sql", synthesized, "route", target)
 				extSpan.SetAttributes(attribute.String("db.statement", truncateStr(synthesized, 100)))
 
-				if err := s.executeSynthesizedQuery(extCtx, clientConn, synthesized, extRoute, session, &boundWriter, extTxStart, extTxEnd); err != nil {
+				if err := s.executeSynthesizedQuery(extCtx, clientConn, synthesized, extRoute, session, &boundWriter, extTxStart, extTxEnd, ct); err != nil {
 					extSpan.SetStatus(codes.Error, err.Error())
 					extSpan.End()
 					slog.Error("execute synthesized query", "error", err)
@@ -361,7 +363,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 			} else if extRoute == router.RouteReader && !session.InTransaction() && boundWriter == nil {
 				// Reader path (proxy mode)
 				readerAddr := s.balancer.Next()
-				if err := s.handleExtendedRead(extCtx, clientConn, extBuf, msg, readerAddr); err != nil {
+				if err := s.handleExtendedRead(extCtx, clientConn, extBuf, msg, readerAddr, ct); err != nil {
 					extSpan.SetStatus(codes.Error, err.Error())
 					extSpan.End()
 					slog.Error("extended read query", "error", err)
@@ -390,8 +392,10 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				)
 
 				// Forward all buffered messages + Sync to writer
+				ct.setFromConn(s.writerAddr, wConn)
 				writeErr := s.forwardExtBatch(wConn, extBuf, msg)
 				if writeErr != nil {
+					ct.clear()
 					execSpan.SetStatus(codes.Error, writeErr.Error())
 					execSpan.End()
 					extSpan.SetStatus(codes.Error, "forward ext batch failed")
@@ -407,6 +411,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				}
 
 				if err := s.relayUntilReady(clientConn, wConn); err != nil {
+					ct.clear()
 					execSpan.SetStatus(codes.Error, err.Error())
 					execSpan.End()
 					extSpan.SetStatus(codes.Error, "relay writer response failed")
@@ -420,6 +425,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 					}
 					return
 				}
+				ct.clear()
 				execSpan.End()
 
 				// Update transaction state for Extended Query

--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -20,7 +20,7 @@ import (
 )
 
 // handleExtendedRead sends buffered Extended Query messages to a reader, falling back to writer.
-func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string) error {
+func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string, ct *cancelTarget) error {
 	// Fallback helper: send entire batch to writer via pool
 	fallbackToWriter := func() error {
 		if s.metrics != nil {
@@ -31,14 +31,18 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 			s.sendError(clientConn, "no available backend connections")
 			return fmt.Errorf("acquire writer for ext fallback: %w", err)
 		}
+		ct.setFromConn(s.writerAddr, wConn)
 		if err := s.forwardExtBatch(wConn, buf, syncMsg); err != nil {
+			ct.clear()
 			s.writerPool.Discard(wConn)
 			return fmt.Errorf("forward ext to writer: %w", err)
 		}
 		if err := s.relayUntilReady(clientConn, wConn); err != nil {
+			ct.clear()
 			s.writerPool.Discard(wConn)
 			return err
 		}
+		ct.clear()
 		s.resetAndReleaseWriter(wConn)
 		return nil
 	}
@@ -77,8 +81,11 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		trace.WithAttributes(attribute.String("pgmux.route", "reader")),
 	)
 
+	ct.setFromConn(readerAddr, rConn)
+
 	// Forward all buffered messages + Sync to reader
 	if err := s.forwardExtBatch(rConn, buf, syncMsg); err != nil {
+		ct.clear()
 		execSpan.SetStatus(codes.Error, err.Error())
 		execSpan.End()
 		slog.Error("forward ext to reader", "addr", readerAddr, "error", err)
@@ -89,6 +96,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 	// Relay response from reader (with optional caching)
 	if s.queryCache != nil {
 		collected, err := s.relayAndCollect(clientConn, rConn)
+		ct.clear()
 		rPool.Release(rConn)
 		execSpan.End()
 		if err != nil {
@@ -105,11 +113,13 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		}
 	} else {
 		if err := s.relayUntilReady(clientConn, rConn); err != nil {
+			ct.clear()
 			execSpan.SetStatus(codes.Error, err.Error())
 			execSpan.End()
 			rPool.Discard(rConn)
 			return fmt.Errorf("relay reader extended response: %w", err)
 		}
+		ct.clear()
 		rPool.Release(rConn)
 		execSpan.End()
 	}
@@ -131,14 +141,14 @@ func (s *Server) forwardExtBatch(backendConn net.Conn, buf []*protocol.Message, 
 }
 
 // executeSynthesizedQuery executes a synthesized Simple Query on the appropriate backend.
-func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Conn, query string, route router.Route, session *router.Session, boundWriter **pool.Conn, extTxStart, extTxEnd bool) error {
+func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Conn, query string, route router.Route, session *router.Session, boundWriter **pool.Conn, extTxStart, extTxEnd bool, ct *cancelTarget) error {
 	// Build Simple Query message
 	queryPayload := append([]byte(query), 0)
 
 	if route == router.RouteReader && !session.InTransaction() && *boundWriter == nil {
 		// Reader path
 		readerAddr := s.balancer.Next()
-		return s.handleSynthesizedRead(ctx, clientConn, queryPayload, readerAddr)
+		return s.handleSynthesizedRead(ctx, clientConn, queryPayload, readerAddr, ct)
 	}
 
 	// Writer path
@@ -148,7 +158,9 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 		return fmt.Errorf("acquire writer for synthesized query: %w", err)
 	}
 
+	ct.setFromConn(s.writerAddr, wConn)
 	if err := protocol.WriteMessage(wConn, protocol.MsgQuery, queryPayload); err != nil {
+		ct.clear()
 		if acquired {
 			s.writerPool.Discard(wConn)
 		}
@@ -156,6 +168,7 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 	}
 
 	if err := s.relayUntilReady(clientConn, wConn); err != nil {
+		ct.clear()
 		if acquired {
 			s.writerPool.Discard(wConn)
 		} else if *boundWriter != nil {
@@ -164,6 +177,7 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 		}
 		return fmt.Errorf("relay synthesized response: %w", err)
 	}
+	ct.clear()
 
 	// Update transaction state
 	if extTxStart {
@@ -186,7 +200,7 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 }
 
 // handleSynthesizedRead sends a synthesized Simple Query to a reader.
-func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn, queryPayload []byte, readerAddr string) error {
+func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn, queryPayload []byte, readerAddr string, ct *cancelTarget) error {
 	fallbackToWriter := func() error {
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
@@ -196,14 +210,18 @@ func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn,
 			s.sendError(clientConn, "no available backend connections")
 			return fmt.Errorf("acquire writer for synthesized fallback: %w", err)
 		}
+		ct.setFromConn(s.writerAddr, wConn)
 		if err := protocol.WriteMessage(wConn, protocol.MsgQuery, queryPayload); err != nil {
+			ct.clear()
 			s.writerPool.Discard(wConn)
 			return fmt.Errorf("send synthesized to writer: %w", err)
 		}
 		if err := s.relayUntilReady(clientConn, wConn); err != nil {
+			ct.clear()
 			s.writerPool.Discard(wConn)
 			return err
 		}
+		ct.clear()
 		s.resetAndReleaseWriter(wConn)
 		return nil
 	}
@@ -222,22 +240,26 @@ func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn,
 		return fallbackToWriter()
 	}
 
+	ct.setFromConn(readerAddr, rConn)
 	if err := protocol.WriteMessage(rConn, protocol.MsgQuery, queryPayload); err != nil {
+		ct.clear()
 		rPool.Discard(rConn)
 		return fallbackToWriter()
 	}
 
 	if err := s.relayUntilReady(clientConn, rConn); err != nil {
+		ct.clear()
 		rPool.Discard(rConn)
 		return fmt.Errorf("relay reader synthesized response: %w", err)
 	}
+	ct.clear()
 	rPool.Release(rConn)
 	return nil
 }
 
 // handleMultiplexDescribe handles Describe messages in multiplex mode.
 // It forwards a temporary Parse → Describe → Close to the backend and relays results.
-func (s *Server) handleMultiplexDescribe(ctx context.Context, clientConn net.Conn, msg *protocol.Message, synth *Synthesizer, boundWriter *pool.Conn) error {
+func (s *Server) handleMultiplexDescribe(ctx context.Context, clientConn net.Conn, msg *protocol.Message, synth *Synthesizer, boundWriter *pool.Conn, ct *cancelTarget) error {
 	if len(msg.Payload) < 2 {
 		s.sendError(clientConn, "invalid describe message")
 		return nil

--- a/internal/proxy/query_read.go
+++ b/internal/proxy/query_read.go
@@ -18,7 +18,7 @@ import (
 
 // handleReadQueryTraced wraps handleReadQuery with OpenTelemetry child spans for
 // cache lookup, pool acquire, backend exec, and cache store.
-func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session) error {
+func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session, ct *cancelTarget) error {
 	// Cache lookup span
 	_, cacheLookupSpan := telemetry.Tracer().Start(traceCtx, "pgmux.cache.lookup")
 	if s.queryCache != nil {
@@ -53,7 +53,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.fallbackToWriter(poolCtx, clientConn, msg)
+		return s.fallbackToWriter(poolCtx, clientConn, msg, ct)
 	}
 
 	// Circuit breaker check for reader
@@ -63,7 +63,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 			if s.metrics != nil {
 				s.metrics.ReaderFallback.Inc()
 			}
-			return s.fallbackToWriter(poolCtx, clientConn, msg)
+			return s.fallbackToWriter(poolCtx, clientConn, msg, ct)
 		}
 	}
 
@@ -73,7 +73,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.fallbackToWriter(poolCtx, clientConn, msg)
+		return s.fallbackToWriter(poolCtx, clientConn, msg, ct)
 	}
 
 	// Pool acquire span
@@ -92,7 +92,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		if cb, ok := s.getReaderCB(readerAddr); ok {
 			cb.RecordFailure()
 		}
-		return s.fallbackToWriter(poolCtx, clientConn, msg)
+		return s.fallbackToWriter(poolCtx, clientConn, msg, ct)
 	}
 	acquireSpan.End()
 	if s.metrics != nil {
@@ -105,18 +105,22 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		trace.WithAttributes(attribute.String("pgmux.route", "reader")),
 	)
 
+	ct.setFromConn(readerAddr, rConn)
+
 	// Forward query to reader
 	if err := protocol.WriteMessage(rConn, msg.Type, msg.Payload); err != nil {
+		ct.clear()
 		execSpan.SetStatus(codes.Error, err.Error())
 		execSpan.End()
 		slog.Error("forward to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
-		return s.fallbackToWriter(poolCtx, clientConn, msg)
+		return s.fallbackToWriter(poolCtx, clientConn, msg, ct)
 	}
 
 	// Relay response and collect bytes for caching
 	if s.queryCache != nil {
 		collected, err := s.relayAndCollect(clientConn, rConn)
+		ct.clear()
 		execSpan.End()
 		if err != nil {
 			rPool.Discard(rConn)
@@ -139,6 +143,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		}
 	} else {
 		if err := s.relayUntilReady(clientConn, rConn); err != nil {
+			ct.clear()
 			execSpan.SetStatus(codes.Error, err.Error())
 			execSpan.End()
 			rPool.Discard(rConn)
@@ -147,6 +152,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 			}
 			return fmt.Errorf("relay reader response: %w", err)
 		}
+		ct.clear()
 		rPool.Release(rConn)
 		execSpan.End()
 	}
@@ -158,7 +164,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 }
 
 // handleReadQuery checks cache, acquires a reader from pool, or falls back to writer.
-func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session) error {
+func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session, ct *cancelTarget) error {
 	// Check cache
 	if s.queryCache != nil {
 		key := s.cacheKey(query)
@@ -188,7 +194,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.fallbackToWriter(ctx, clientConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg, ct)
 	}
 
 	// Circuit breaker check for reader
@@ -198,7 +204,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 			if s.metrics != nil {
 				s.metrics.ReaderFallback.Inc()
 			}
-			return s.fallbackToWriter(ctx, clientConn, msg)
+			return s.fallbackToWriter(ctx, clientConn, msg, ct)
 		}
 	}
 
@@ -208,7 +214,7 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		if s.metrics != nil {
 			s.metrics.ReaderFallback.Inc()
 		}
-		return s.fallbackToWriter(ctx, clientConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg, ct)
 	}
 
 	acquireStart := time.Now()
@@ -221,24 +227,28 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		if cb, ok := s.getReaderCB(readerAddr); ok {
 			cb.RecordFailure()
 		}
-		return s.fallbackToWriter(ctx, clientConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg, ct)
 	}
 	if s.metrics != nil {
 		s.metrics.PoolAcquires.WithLabelValues("reader", readerAddr).Inc()
 		s.metrics.PoolAcquireDur.WithLabelValues("reader", readerAddr).Observe(time.Since(acquireStart).Seconds())
 	}
 
+	ct.setFromConn(readerAddr, rConn)
+
 	// Forward query to reader
 	if err := protocol.WriteMessage(rConn, msg.Type, msg.Payload); err != nil {
+		ct.clear()
 		slog.Error("forward to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
 		// Fallback to writer
-		return s.fallbackToWriter(ctx, clientConn, msg)
+		return s.fallbackToWriter(ctx, clientConn, msg, ct)
 	}
 
 	// Relay response and collect bytes for caching
 	if s.queryCache != nil {
 		collected, err := s.relayAndCollect(clientConn, rConn)
+		ct.clear()
 		rPool.Release(rConn)
 		if err != nil {
 			return fmt.Errorf("relay reader response: %w", err)
@@ -253,12 +263,14 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		}
 	} else {
 		if err := s.relayUntilReady(clientConn, rConn); err != nil {
+			ct.clear()
 			rPool.Discard(rConn)
 			if cb, ok := s.getReaderCB(readerAddr); ok {
 				cb.RecordFailure()
 			}
 			return fmt.Errorf("relay reader response: %w", err)
 		}
+		ct.clear()
 		rPool.Release(rConn)
 	}
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jyukki97/pgmux/internal/audit"
@@ -38,6 +39,8 @@ type Server struct {
 	rateLimiter  *resilience.RateLimiter
 	auditLogger  *audit.Logger
 	wg           sync.WaitGroup
+	cancelMap    sync.Map         // cancelKeyPair → *cancelTarget
+	nextProxyPID atomic.Uint32
 }
 
 func NewServer(cfg *config.Config) *Server {
@@ -320,14 +323,27 @@ func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
 		}
 	}
 
+	// Handle CancelRequest (new TCP connection for query cancellation)
+	if len(startup.Payload) >= 4 {
+		code := binary.BigEndian.Uint32(startup.Payload[0:4])
+		if code == protocol.CancelRequestCode {
+			s.handleCancelRequest(startup.Payload)
+			return
+		}
+	}
+
 	_, _, params := protocol.ParseStartupParams(startup.Payload)
 	slog.Info("client startup", "user", params["user"], "database", params["database"])
 
-	// 3. Authenticate client
+	// 3. Generate proxy cancel key for this session
+	ct := s.newCancelTarget()
+	defer s.removeCancelTarget(ct)
+
+	// 4. Authenticate client
 	cfg := s.getConfig()
 	if cfg.Auth.Enabled {
 		// Front-end auth: proxy authenticates the client directly using MD5.
-		if err := s.frontendAuth(clientConn, params["user"]); err != nil {
+		if err := s.frontendAuth(clientConn, params["user"], ct.proxyPID, ct.proxySecret); err != nil {
 			slog.Warn("frontend auth failed", "user", params["user"], "remote", rawConn.RemoteAddr(), "error", err)
 			return
 		}
@@ -350,7 +366,7 @@ func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
 			return
 		}
 
-		if err := s.relayAuth(clientConn, authConn); err != nil {
+		if err := s.relayAuth(clientConn, authConn, ct.proxyPID, ct.proxySecret); err != nil {
 			authConn.Close()
 			slog.Error("auth relay", "error", err)
 			return
@@ -360,11 +376,11 @@ func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
 
 	slog.Info("handshake complete", "remote", rawConn.RemoteAddr())
 
-	// 4. Create per-client session router
+	// 5. Create per-client session router
 	session := router.NewSession(cfg.Routing.ReadAfterWriteDelay, cfg.Routing.CausalConsistency)
 
-	// 5. Relay queries with transaction-level pooling
-	s.relayQueries(ctx, clientConn, session)
+	// 6. Relay queries with transaction-level pooling
+	s.relayQueries(ctx, clientConn, session, ct)
 }
 
 // Reload applies a new configuration without restarting the proxy.


### PR DESCRIPTION
## 변경 사항
- `CancelRequestCode` (80877102) 상수 추가 및 `handleConn()`에서 cancel request 감지
- `pgConnect()`에서 BackendKeyData 캡처 → `pool.Conn.BackendPID/BackendSecret`에 저장
- 프록시 cancel key 매핑 테이블 (`sync.Map`) 구현
  - 세션별 고유 프록시 PID+secret 생성 → 클라이언트에 BackendKeyData로 전송
  - `relayAuth`: 백엔드 BackendKeyData를 프록시 키로 교체
  - `frontendAuth`: 프록시 BackendKeyData 전송 추가
- cancel request → 매핑 테이블 조회 → 올바른 백엔드에 전달
- `relayQueries` 및 하위 함수들에서 backend acquire/release 시 cancel 상태 추적

## 테스트
- `TestCancelTarget_SetAndGet` — cancel target set/get/clear 검증
- `TestServer_CancelKeyRegistration` — cancel map 등록/삭제 검증
- `TestServer_CancelRequestForwarding` — 실제 TCP로 cancel 전달 검증
- `TestServer_HandleCancelRequest_Integration` — 전체 흐름 통합 테스트
- `go test -race ./internal/proxy/` 전체 PASS

closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)