### PR TITLE
fix(dataapi): API 키 인증이 핫 리로드 후 갱신되지 않음 (#127)

### DIFF
--- a/internal/dataapi/cancel_leak_test.go
+++ b/internal/dataapi/cancel_leak_test.go
@@ -145,7 +145,7 @@ func TestExecuteOnPool_ContextCancel(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(cfg, p, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -210,7 +210,7 @@ func TestExecuteOnPool_NormalCompletion(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(cfg, p, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
 
 	ctx := context.Background()
 
@@ -262,7 +262,7 @@ func TestExecuteOnPool_DeadlineExceeded(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(cfg, p, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()

--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -56,18 +56,12 @@ type Server struct {
 	queryCacheFn  func() *cache.Cache
 	met           *metrics.Metrics
 	rateLimiterFn func() *resilience.RateLimiter
-	apiKeys       map[string]bool
 }
 
 // New creates a new Data API server.
 // Pool, balancer, cache, and rate limiter parameters are getter functions so
 // that Data API always accesses the latest objects even after a hot-reload.
 func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPoolsFn func() map[string]*pool.Pool, balancerFn func() *router.RoundRobin, queryCacheFn func() *cache.Cache, met *metrics.Metrics, rateLimiterFn func() *resilience.RateLimiter) *Server {
-	cfg := cfgFn()
-	keys := make(map[string]bool, len(cfg.DataAPI.APIKeys))
-	for _, k := range cfg.DataAPI.APIKeys {
-		keys[k] = true
-	}
 	return &Server{
 		cfgFn:         cfgFn,
 		writerPoolFn:  writerPoolFn,
@@ -76,7 +70,6 @@ func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPool
 		queryCacheFn:  queryCacheFn,
 		met:           met,
 		rateLimiterFn: rateLimiterFn,
-		apiKeys:       keys,
 	}
 }
 
@@ -99,10 +92,18 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 	propagator := otel.GetTextMapPropagator()
 	ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 
-	// Auth check
-	if len(s.apiKeys) > 0 {
+	// Auth check — read API keys from live config so hot-reload takes effect
+	apiKeys := s.cfgFn().DataAPI.APIKeys
+	if len(apiKeys) > 0 {
 		token := extractBearerToken(r)
-		if token == "" || !s.apiKeys[token] {
+		allowed := false
+		for _, k := range apiKeys {
+			if k == token {
+				allowed = true
+				break
+			}
+		}
+		if token == "" || !allowed {
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}


### PR DESCRIPTION
## 변경 사항
- `Server.apiKeys` 스냅샷 맵 제거, 요청마다 `cfgFn().DataAPI.APIKeys`를 동적 조회
- 테스트 파일(`cancel_leak_test.go`)의 `New()` 호출부를 getter 함수 패턴으로 수정

## 테스트
- `go build ./...` 통과
- `go test ./internal/dataapi/...` 통과

closes #127