### PR TITLE
fix(dataapi): 멀티 인스턴스 캐시 무효화 전파 누락 (#128)

### DIFF
--- a/cmd/pgmux/main.go
+++ b/cmd/pgmux/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jyukki97/pgmux/internal/admin"
+	"github.com/jyukki97/pgmux/internal/cache"
 	"github.com/jyukki97/pgmux/internal/config"
 	"github.com/jyukki97/pgmux/internal/dataapi"
 	"github.com/jyukki97/pgmux/internal/proxy"
@@ -90,7 +91,7 @@ func run() error {
 
 	// Start Data API server
 	if cfg.DataAPI.Enabled {
-		apiSrv := dataapi.New(srv.Cfg, srv.WriterPool, srv.ReaderPools, srv.Balancer, srv.Cache, srv.ProxyMetrics(), srv.RateLimiter)
+		apiSrv := dataapi.New(srv.Cfg, srv.WriterPool, srv.ReaderPools, srv.Balancer, srv.Cache, srv.ProxyMetrics(), srv.RateLimiter, func() *cache.Invalidator { return srv.Invalidator() })
 		go func() {
 			if err := apiSrv.ListenAndServe(cfg.DataAPI.Listen); err != nil && err != http.ErrServerClosed {
 				slog.Error("data api server error", "error", err)

--- a/internal/dataapi/cancel_leak_test.go
+++ b/internal/dataapi/cancel_leak_test.go
@@ -145,7 +145,7 @@ func TestExecuteOnPool_ContextCancel(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -210,7 +210,7 @@ func TestExecuteOnPool_NormalCompletion(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil, nil)
 
 	ctx := context.Background()
 
@@ -262,7 +262,7 @@ func TestExecuteOnPool_DeadlineExceeded(t *testing.T) {
 	cfg := &config.Config{
 		Pool: config.PoolConfig{ResetQuery: "DISCARD ALL"},
 	}
-	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil)
+	srv := New(func() *config.Config { return cfg }, func() *pool.Pool { return p }, nil, nil, nil, nil, nil, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()

--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -54,22 +54,24 @@ type Server struct {
 	readerPoolsFn func() map[string]*pool.Pool
 	balancerFn    func() *router.RoundRobin
 	queryCacheFn  func() *cache.Cache
-	met           *metrics.Metrics
-	rateLimiterFn func() *resilience.RateLimiter
+	met            *metrics.Metrics
+	rateLimiterFn  func() *resilience.RateLimiter
+	invalidatorFn  func() *cache.Invalidator
 }
 
 // New creates a new Data API server.
 // Pool, balancer, cache, and rate limiter parameters are getter functions so
 // that Data API always accesses the latest objects even after a hot-reload.
-func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPoolsFn func() map[string]*pool.Pool, balancerFn func() *router.RoundRobin, queryCacheFn func() *cache.Cache, met *metrics.Metrics, rateLimiterFn func() *resilience.RateLimiter) *Server {
+func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPoolsFn func() map[string]*pool.Pool, balancerFn func() *router.RoundRobin, queryCacheFn func() *cache.Cache, met *metrics.Metrics, rateLimiterFn func() *resilience.RateLimiter, invalidatorFn func() *cache.Invalidator) *Server {
 	return &Server{
-		cfgFn:         cfgFn,
-		writerPoolFn:  writerPoolFn,
-		readerPoolsFn: readerPoolsFn,
-		balancerFn:    balancerFn,
-		queryCacheFn:  queryCacheFn,
-		met:           met,
-		rateLimiterFn: rateLimiterFn,
+		cfgFn:          cfgFn,
+		writerPoolFn:   writerPoolFn,
+		readerPoolsFn:  readerPoolsFn,
+		balancerFn:     balancerFn,
+		queryCacheFn:   queryCacheFn,
+		met:            met,
+		rateLimiterFn:  rateLimiterFn,
+		invalidatorFn:  invalidatorFn,
 	}
 }
 
@@ -292,6 +294,12 @@ func (s *Server) executeWrite(ctx context.Context, sql string) (*QueryResponse, 
 			if s.met != nil {
 				s.met.CacheInvalidations.Inc()
 				s.met.CacheEntries.Set(float64(queryCache.Len()))
+			}
+		}
+		// Broadcast invalidation to other proxy instances
+		if s.invalidatorFn != nil {
+			if inv := s.invalidatorFn(); inv != nil && len(tables) > 0 {
+				inv.Publish(context.Background(), tables)
 			}
 		}
 	}

--- a/internal/dataapi/handler_test.go
+++ b/internal/dataapi/handler_test.go
@@ -26,7 +26,7 @@ func testServer() *Server {
 	}
 	return New(
 		func() *config.Config { return cfg },
-		nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter,
+		nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter, nil,
 	)
 }
 
@@ -105,7 +105,7 @@ func TestEmptySQL(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter, nil)
 
 	body := `{"sql": ""}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))
@@ -122,7 +122,7 @@ func TestInvalidBody(t *testing.T) {
 		Pool:    config.PoolConfig{ResetQuery: "DISCARD ALL"},
 		DataAPI: config.DataAPIConfig{Enabled: true},
 	}
-	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter, nil)
 
 	body := `not json`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))
@@ -144,7 +144,7 @@ func TestFirewallBlock(t *testing.T) {
 		Routing: config.RoutingConfig{ASTParser: true},
 		DataAPI: config.DataAPIConfig{Enabled: true},
 	}
-	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter)
+	srv := New(func() *config.Config { return cfg }, nilPool, nilPools, nilBalancer, nilCache, nil, nilRateLimiter, nil)
 
 	body := `{"sql": "DELETE FROM users"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/query", bytes.NewBufferString(body))


### PR DESCRIPTION
## 변경 사항
- `Server` 구조체에 `invalidatorFn func() *cache.Invalidator` 추가
- `executeWrite()`에서 로컬 캐시 무효화 후 `invalidator.Publish()` 호출 추가
- `main.go`에서 `dataapi.New()` 호출 시 invalidator getter 전달
- 테스트 파일 시그니처 갱신

## 테스트
- `go build ./...` 통과
- `go test ./internal/dataapi/...` 통과

closes #128