### PR TITLE
fix(config): ConfigMap symlink swap 이벤트 미감지 (#129)

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -108,22 +108,18 @@ func (fw *FileWatcher) Stop() {
 
 // isTargetEvent returns true if the event is relevant to the watched file.
 func (fw *FileWatcher) isTargetEvent(event fsnotify.Event) bool {
-	// Only respond to write, create, and rename events.
-	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
-		return false
-	}
-
 	eventBase := filepath.Base(event.Name)
 
 	// Direct match: the config file itself was modified.
-	if eventBase == fw.fileName {
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0 && eventBase == fw.fileName {
 		return true
 	}
 
 	// K8s ConfigMap symlink swap: when K8s updates a mounted ConfigMap,
-	// it atomically swaps a "..data" symlink. Detect CREATE events on
-	// symlink-like entries (prefixed with "..") in the watched directory.
-	if event.Op&fsnotify.Create != 0 && strings.HasPrefix(eventBase, "..") {
+	// it atomically swaps a "..data" symlink via os.Rename. Depending on
+	// the OS/filesystem, this produces CREATE, RENAME, or REMOVE events.
+	// Accept any mutation event on ".." prefixed entries.
+	if event.Op != 0 && strings.HasPrefix(eventBase, "..") {
 		return true
 	}
 


### PR DESCRIPTION
## 변경 사항
- `isTargetEvent()`에서 `..` 접두사 엔트리에 대해 CREATE만 허용하던 조건을 모든 mutation 이벤트로 확대
- macOS(kqueue)에서 `os.Rename` 시 RENAME/REMOVE 이벤트가 발생하는 케이스 커버

## 테스트
- `go test ./internal/config/...` 통과 (SymlinkSwap 포함)
- `go test -race ./internal/config/...` 통과

closes #129