### PR TITLE
fix(admin): /admin/reload 실패 시 HTTP 500 반환 (#137)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -266,6 +266,7 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 
 	if err := fn(); err != nil {
 		slog.Error("admin: reload failed", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]any{"status": "error", "error": err.Error()})
 		return
 	}

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -208,8 +208,8 @@ func TestHandleReload_Error(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleReload(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", w.Code)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
 	}
 
 	var resp map[string]any


### PR DESCRIPTION
## 변경 사항
- `/admin/reload` 에러 분기에 `w.WriteHeader(http.StatusInternalServerError)` 추가
- 테스트 기대값을 200 → 500으로 수정

## 테스트
- `TestHandleReload_Error` 통과 확인 (500 검증)
- `TestHandleReload_Success` 기존 동작 유지 (200)

closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)