### PR TITLE
fix(audit): 웹훅 goroutine WaitGroup 추적으로 종료 시 유실 방지 (#138)

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -150,7 +150,11 @@ func (l *Logger) handleEvent(e Event) {
 		)
 
 		if l.httpClient != nil {
-			go l.sendWebhook(e)
+			l.wg.Add(1)
+			go func() {
+				defer l.wg.Done()
+				l.sendWebhook(e)
+			}()
 		}
 	} else if l.cfg.LogAllQueries {
 		e.EventType = "query"


### PR DESCRIPTION
## 변경 사항
- `sendWebhook` goroutine 실행 시 `l.wg.Add(1)` / `defer l.wg.Done()` 추가
- `Close()` → `wg.Wait()`이 모든 in-flight 웹훅 완료를 보장

## 테스트
- `go test ./internal/audit/ -race` 전체 통과
- race condition 없음 확인

closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)