### PR TITLE
fix(admin): handleReload Content-Type 누락 + SetReloadFunc race + 동시 reload 직렬화

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -30,6 +30,8 @@ type Server struct {
 
 // SetReloadFunc sets the function to call when reload is requested.
 func (s *Server) SetReloadFunc(fn func() error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.reloadFunc = fn
 }
 
@@ -255,19 +257,20 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.mu.RLock()
+	s.mu.Lock()
 	fn := s.reloadFunc
-	s.mu.RUnlock()
-
 	if fn == nil {
+		s.mu.Unlock()
 		http.Error(w, "reload not configured", http.StatusServiceUnavailable)
 		return
 	}
+	defer s.mu.Unlock()
 
 	if err := fn(); err != nil {
 		slog.Error("admin: reload failed", "error", err)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		writeJSON(w, map[string]any{"status": "error", "error": err.Error()})
+		json.NewEncoder(w).Encode(map[string]any{"status": "error", "error": err.Error()})
 		return
 	}
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,6 +233,37 @@ func TestHandleReload_NotConfigured(t *testing.T) {
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestHandleReload_Error_ContentType(t *testing.T) {
+	srv, _ := testServer()
+	srv.SetReloadFunc(func() error {
+		return fmt.Errorf("config parse error")
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(srv.handleReload))
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["status"] != "error" {
+		t.Errorf("status = %q, want error", body["status"])
 	}
 }
 


### PR DESCRIPTION
## 변경 사항

### 1. handleReload 에러 응답 Content-Type 누락 수정 (중간)
- `WriteHeader(500)` 호출 후 `writeJSON()`에서 Content-Type 설정 → Go `net/http` 문서상 WriteHeader 이후 헤더 변경은 무효
- **수정**: Content-Type을 WriteHeader 전에 설정, `writeJSON` 대신 직접 인코딩

### 2. SetReloadFunc data race 수정 (중간)
- `SetReloadFunc`이 `mu` 잠금 없이 `reloadFunc` 필드에 쓰기 → `handleReload`의 읽기와 data race
- **수정**: `mu.Lock()` 추가

### 3. 동시 reload 직렬화 (낮음)
- `handleReload`가 `RLock` 사용 → 여러 goroutine이 동시에 reload 실행 가능
- **수정**: `RLock` → `Lock`으로 변경, reload 실행 중 뮤텍스 유지

## 테스트
- `TestHandleReload_Error_ContentType` 추가: `httptest.NewServer`로 실제 HTTP 응답의 Content-Type 검증 (`httptest.ResponseRecorder`는 WriteHeader 이후 헤더 변경 제한을 강제하지 않아 회귀 감지 불가)
- 전체 admin 테스트 통과 (`go test -race -count=1`)

closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)