### PR TITLE
fix(router): AST 분류 결과를 실제 라우팅에 반영 (#143)

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -389,7 +389,7 @@ func (s *Server) handleConn(ctx context.Context, rawConn net.Conn) {
 	slog.Info("handshake complete", "remote", rawConn.RemoteAddr())
 
 	// 5. Create per-client session router
-	session := router.NewSession(cfg.Routing.ReadAfterWriteDelay, cfg.Routing.CausalConsistency)
+	session := router.NewSession(cfg.Routing.ReadAfterWriteDelay, cfg.Routing.CausalConsistency, cfg.Routing.ASTParser)
 
 	// 6. Relay queries with transaction-level pooling
 	s.relayQueries(ctx, clientConn, session, ct)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -20,15 +20,17 @@ type Session struct {
 	readAfterWriteDelay time.Duration
 	causalConsistency   bool
 	lastWriteLSN        LSN
+	astParser           bool
 
 	// Prepared statement routing: statement name → route
 	stmtRoutes map[string]Route
 }
 
-func NewSession(readAfterWriteDelay time.Duration, causalConsistency bool) *Session {
+func NewSession(readAfterWriteDelay time.Duration, causalConsistency bool, astParser bool) *Session {
 	return &Session{
 		readAfterWriteDelay: readAfterWriteDelay,
 		causalConsistency:   causalConsistency,
+		astParser:           astParser,
 		stmtRoutes:          make(map[string]Route),
 	}
 }
@@ -53,7 +55,12 @@ func (s *Session) Route(query string) Route {
 		return RouteWriter
 	}
 
-	qtype := Classify(query)
+	var qtype QueryType
+	if s.astParser {
+		qtype = ClassifyAST(query)
+	} else {
+		qtype = Classify(query)
+	}
 
 	// Write query
 	if qtype == QueryWrite {
@@ -215,7 +222,13 @@ func (s *Session) routeLocked(query string) Route {
 		return RouteWriter
 	}
 
-	if Classify(query) == QueryWrite {
+	var qtype QueryType
+	if s.astParser {
+		qtype = ClassifyAST(query)
+	} else {
+		qtype = Classify(query)
+	}
+	if qtype == QueryWrite {
 		return RouteWriter
 	}
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSession_BasicRouting(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	if got := s.Route("SELECT * FROM users"); got != RouteReader {
 		t.Errorf("SELECT → %d, want RouteReader", got)
@@ -17,7 +17,7 @@ func TestSession_BasicRouting(t *testing.T) {
 }
 
 func TestSession_Transaction(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// BEGIN → all queries go to writer
 	if got := s.Route("BEGIN"); got != RouteWriter {
@@ -40,7 +40,7 @@ func TestSession_Transaction(t *testing.T) {
 }
 
 func TestSession_ReadAfterWriteDelay(t *testing.T) {
-	s := NewSession(100 * time.Millisecond, false)
+	s := NewSession(100*time.Millisecond, false, false)
 
 	// Write
 	s.Route("INSERT INTO users VALUES (1)")
@@ -60,7 +60,7 @@ func TestSession_ReadAfterWriteDelay(t *testing.T) {
 }
 
 func TestSession_Rollback(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	s.Route("BEGIN")
 	if !s.InTransaction() {
@@ -78,7 +78,7 @@ func TestSession_Rollback(t *testing.T) {
 }
 
 func TestSession_PreparedStatements(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// Register a SELECT prepared statement → reader
 	route := s.RegisterStatement("stmt_read", "SELECT * FROM users WHERE id = $1")
@@ -113,7 +113,7 @@ func TestSession_PreparedStatements(t *testing.T) {
 }
 
 func TestSession_PreparedStatement_InTransaction(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// Start transaction
 	s.Route("BEGIN")
@@ -134,7 +134,7 @@ func TestSession_PreparedStatement_InTransaction(t *testing.T) {
 }
 
 func TestSession_UnnamedStatement(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// Unnamed statement (empty string) — overwritten on each Parse
 	s.RegisterStatement("", "SELECT 1")
@@ -150,7 +150,7 @@ func TestSession_UnnamedStatement(t *testing.T) {
 }
 
 func TestSession_MultiStatementCommit(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// Start transaction
 	s.Route("BEGIN")
@@ -171,7 +171,7 @@ func TestSession_MultiStatementCommit(t *testing.T) {
 }
 
 func TestSession_MultiStatementBegin(t *testing.T) {
-	s := NewSession(0, false)
+	s := NewSession(0, false, false)
 
 	// Multi-statement with BEGIN embedded
 	s.Route("SELECT 1; BEGIN;")
@@ -186,7 +186,7 @@ func TestSession_MultiStatementBegin(t *testing.T) {
 }
 
 func TestSession_CausalConsistency_LSNTracking(t *testing.T) {
-	s := NewSession(0, true)
+	s := NewSession(0, true, false)
 
 	// Initially no LSN
 	if lsn := s.LastWriteLSN(); !lsn.IsZero() {
@@ -217,13 +217,73 @@ func TestSession_CausalConsistency_LSNTracking(t *testing.T) {
 
 func TestSession_CausalConsistency_SkipsTimerDelay(t *testing.T) {
 	// With causal consistency ON, read_after_write_delay should be ignored
-	s := NewSession(100*time.Millisecond, true)
+	s := NewSession(100*time.Millisecond, true, false)
 
 	s.Route("INSERT INTO users VALUES (1)")
 
 	// In causal mode, reads should NOT be routed to writer by timer
 	if got := s.Route("SELECT * FROM users"); got != RouteReader {
 		t.Errorf("SELECT in causal mode → %d, want RouteReader (timer should be skipped)", got)
+	}
+}
+
+func TestSession_ASTParser_CTEWithInsert(t *testing.T) {
+	// With AST mode on, CTE containing INSERT routes to writer
+	s := NewSession(0, false, true)
+
+	query := "WITH ins AS (INSERT INTO users (name) VALUES ('alice') RETURNING id) SELECT * FROM ins"
+	if got := s.Route(query); got != RouteWriter {
+		t.Errorf("AST mode: CTE with INSERT → %d, want RouteWriter", got)
+	}
+}
+
+func TestSession_ASTParser_CTEWithUpdate(t *testing.T) {
+	// With AST mode on, CTE containing UPDATE routes to writer
+	s := NewSession(0, false, true)
+
+	query := "WITH upd AS (UPDATE users SET name = 'bob' WHERE id = 1 RETURNING id) SELECT * FROM upd"
+	if got := s.Route(query); got != RouteWriter {
+		t.Errorf("AST mode: CTE with UPDATE → %d, want RouteWriter", got)
+	}
+}
+
+func TestSession_StringParser_CTEWithInsert(t *testing.T) {
+	// With AST mode off, same CTE query still uses string-based classification
+	s := NewSession(0, false, false)
+
+	query := "WITH ins AS (INSERT INTO users (name) VALUES ('alice') RETURNING id) SELECT * FROM ins"
+	if got := s.Route(query); got != RouteWriter {
+		t.Errorf("String mode: CTE with INSERT → %d, want RouteWriter", got)
+	}
+}
+
+func TestSession_ASTParser_SelectRouteReader(t *testing.T) {
+	// Standard SELECT routes to reader in both modes
+	queryAST := NewSession(0, false, true)
+	queryString := NewSession(0, false, false)
+
+	query := "SELECT * FROM users WHERE id = 1"
+	if got := queryAST.Route(query); got != RouteReader {
+		t.Errorf("AST mode: SELECT → %d, want RouteReader", got)
+	}
+	if got := queryString.Route(query); got != RouteReader {
+		t.Errorf("String mode: SELECT → %d, want RouteReader", got)
+	}
+}
+
+func TestSession_ASTParser_PreparedStatement(t *testing.T) {
+	// Prepared statement routing also respects AST parser setting
+	s := NewSession(0, false, true)
+
+	route := s.RegisterStatement("stmt_cte",
+		"WITH ins AS (INSERT INTO users (name) VALUES ($1) RETURNING id) SELECT * FROM ins")
+	if route != RouteWriter {
+		t.Errorf("AST mode: RegisterStatement CTE with INSERT → %d, want RouteWriter", route)
+	}
+
+	route = s.RegisterStatement("stmt_select", "SELECT * FROM users WHERE id = $1")
+	if route != RouteReader {
+		t.Errorf("AST mode: RegisterStatement SELECT → %d, want RouteReader", route)
 	}
 }
 

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkExtractTables(b *testing.B) {
 }
 
 func BenchmarkSessionRoute(b *testing.B) {
-	s := router.NewSession(500 * time.Millisecond, false)
+	s := router.NewSession(500*time.Millisecond, false, false)
 	for i := 0; i < b.N; i++ {
 		s.Route("SELECT * FROM users WHERE id = 1")
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -18,7 +18,7 @@ func TestIntegration_RouterWithCache(t *testing.T) {
 		TTL:        time.Second,
 		MaxSize:    4096,
 	})
-	session := router.NewSession(200 * time.Millisecond, false)
+	session := router.NewSession(200*time.Millisecond, false, false)
 
 	// 1. SELECT → Reader route + cache miss
 	query := "SELECT * FROM users WHERE id = 1"
@@ -74,7 +74,7 @@ func TestIntegration_RouterWithCache(t *testing.T) {
 
 // TestIntegration_TransactionRouting tests full transaction flow.
 func TestIntegration_TransactionRouting(t *testing.T) {
-	session := router.NewSession(0, false)
+	session := router.NewSession(0, false, false)
 
 	steps := []struct {
 		query string
@@ -171,7 +171,7 @@ func TestIntegration_CacheTTLAndEviction(t *testing.T) {
 // TestIntegration_CausalConsistency tests LSN-based causal consistency routing.
 func TestIntegration_CausalConsistency(t *testing.T) {
 	rb := router.NewRoundRobin([]string{"reader1:5432", "reader2:5432"})
-	session := router.NewSession(0, true)
+	session := router.NewSession(0, true, false)
 
 	// 1. Before any write, reads go to reader (no LSN constraint)
 	route := session.Route("SELECT * FROM users")
@@ -237,7 +237,7 @@ func TestIntegration_CausalConsistency(t *testing.T) {
 // TestIntegration_CausalConsistency_NoTimerFallback verifies that causal mode
 // doesn't use the timer-based read-after-write delay.
 func TestIntegration_CausalConsistency_NoTimerFallback(t *testing.T) {
-	session := router.NewSession(500*time.Millisecond, true)
+	session := router.NewSession(500*time.Millisecond, true, false)
 
 	// Write
 	session.Route("INSERT INTO users (name) VALUES ('test')")


### PR DESCRIPTION
## 변경 사항
- `Session` 구조체에 `astParser` 필드 추가, `NewSession()`에 파라미터 전달
- `Route()` 및 `routeLocked()`에서 `astParser=true`일 때 `ClassifyAST()` 사용
- `proxy/server.go`에서 `cfg.Routing.ASTParser` 값을 `NewSession()`에 전달
- CTE 내 INSERT/UPDATE 라우팅 테스트 5건 추가

## 테스트
- `go test ./internal/router/...` 전체 통과
- `go test ./tests/...` 통과
- CTE+INSERT, CTE+UPDATE → writer 라우팅 검증
- AST 미사용 시 기존 string-based 동작 유지 확인

closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)