### PR TITLE
fix(cache): 읽기 캐시 저장 시 테이블 메타데이터 전달로 무효화 정상화 (#144)

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -130,6 +130,59 @@ func TestCache_InvalidateTable(t *testing.T) {
 	}
 }
 
+func TestCache_InvalidateTable_ReadCacheWithTables(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 1024})
+
+	// Simulate caching read queries with proper table metadata
+	kUsers := CacheKey("SELECT * FROM users")
+	kOrders := CacheKey("SELECT * FROM orders")
+	kJoin := CacheKey("SELECT * FROM users JOIN orders ON users.id = orders.user_id")
+
+	c.Set(kUsers, []byte("users-result"), []string{"users"})
+	c.Set(kOrders, []byte("orders-result"), []string{"orders"})
+	c.Set(kJoin, []byte("join-result"), []string{"users", "orders"})
+
+	// All entries should be present
+	if c.Len() != 3 {
+		t.Errorf("Len() = %d, want 3", c.Len())
+	}
+
+	// Simulate a write to "users" table — should invalidate kUsers and kJoin
+	c.InvalidateTable("users")
+
+	if got := c.Get(kUsers); got != nil {
+		t.Error("kUsers should be invalidated after write to users table")
+	}
+	if got := c.Get(kJoin); got != nil {
+		t.Error("kJoin should be invalidated after write to users table (multi-table)")
+	}
+
+	// kOrders should still be cached — unrelated table
+	if got := c.Get(kOrders); got == nil {
+		t.Error("kOrders should still exist after write to users table")
+	}
+
+	if c.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", c.Len())
+	}
+}
+
+func TestCache_NilTables_NoInvalidation(t *testing.T) {
+	c := New(Config{MaxEntries: 100, TTL: time.Minute, MaxSize: 1024})
+
+	// Simulate old bug: cache entry with nil tables
+	key := CacheKey("SELECT * FROM users")
+	c.Set(key, []byte("result"), nil)
+
+	// InvalidateTable should NOT remove entries with nil tables (no table index)
+	c.InvalidateTable("users")
+
+	// Entry survives because it has no table metadata — this is the bug scenario
+	if got := c.Get(key); got == nil {
+		t.Error("entry with nil tables should NOT be invalidated (demonstrates the bug)")
+	}
+}
+
 func TestCacheKey_SameQuerySameKey(t *testing.T) {
 	k1 := CacheKey("SELECT * FROM users")
 	k2 := CacheKey("SELECT * FROM users")

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -65,6 +65,14 @@ func (s *Server) extractQueryTables(query string) []string {
 	return router.ExtractTables(query)
 }
 
+// extractReadQueryTables uses AST or string parser based on config to extract tables from read queries.
+func (s *Server) extractReadQueryTables(query string) []string {
+	if s.getConfig().Routing.ASTParser {
+		return router.ExtractReadTablesAST(query)
+	}
+	return router.ExtractReadTables(query)
+}
+
 // truncateSQL returns the first 100 characters of a SQL statement for span attributes.
 func truncateSQL(sql string) string {
 	if len(sql) > 100 {

--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -106,7 +106,8 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		if collected != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
 			_, query := protocol.ParseParseMessage(buf[0].Payload)
 			key := s.cacheKey(query)
-			s.queryCache.Set(key, collected, nil)
+			tables := s.extractReadQueryTables(query)
+			s.queryCache.Set(key, collected, tables)
 			if s.metrics != nil {
 				s.metrics.CacheEntries.Set(float64(s.queryCache.Len()))
 			}

--- a/internal/proxy/query_read.go
+++ b/internal/proxy/query_read.go
@@ -134,7 +134,8 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 			// Cache store span
 			_, storeSpan := telemetry.Tracer().Start(traceCtx, "pgmux.cache.store")
 			key := s.cacheKey(query)
-			s.queryCache.Set(key, collected, nil)
+			tables := s.extractReadQueryTables(query)
+			s.queryCache.Set(key, collected, tables)
 			if s.metrics != nil {
 				s.metrics.CacheEntries.Set(float64(s.queryCache.Len()))
 			}
@@ -255,7 +256,8 @@ func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *
 		}
 		if collected != nil { // nil means oversize, skip cache
 			key := s.cacheKey(query)
-			s.queryCache.Set(key, collected, nil)
+			tables := s.extractReadQueryTables(query)
+			s.queryCache.Set(key, collected, tables)
 			if s.metrics != nil {
 				s.metrics.CacheEntries.Set(float64(s.queryCache.Len()))
 			}

--- a/internal/router/parser.go
+++ b/internal/router/parser.go
@@ -158,6 +158,117 @@ func stripComments(query string) string {
 	return result.String()
 }
 
+// ExtractReadTables extracts table names from read queries (SELECT ... FROM).
+// Handles multi-statement queries, subqueries in FROM clause, and JOINs.
+func ExtractReadTables(query string) []string {
+	seen := make(map[string]bool)
+	var tables []string
+
+	stmts := splitStatements(query)
+	for _, stmt := range stmts {
+		for _, t := range extractReadTablesFromStmt(stmt) {
+			if t != "" && !seen[t] {
+				seen[t] = true
+				tables = append(tables, t)
+			}
+		}
+	}
+
+	return tables
+}
+
+func extractReadTablesFromStmt(stmt string) []string {
+	q := strings.TrimSpace(stmt)
+	upper := strings.ToUpper(q)
+
+	// Only process SELECT or WITH ... SELECT (pure read CTE)
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
+		return nil
+	}
+
+	sanitized := stripStringLiterals(q)
+	upperSanitized := strings.ToUpper(sanitized)
+	var tables []string
+
+	// Find all FROM and JOIN table references
+	for _, kw := range []string{"FROM", "JOIN"} {
+		idx := strings.Index(upperSanitized, kw)
+		for idx >= 0 {
+			// Check word boundary before keyword
+			if idx > 0 {
+				prev := upperSanitized[idx-1]
+				if prev != ' ' && prev != '\n' && prev != '\t' && prev != '(' && prev != ',' {
+					next := strings.Index(upperSanitized[idx+len(kw):], kw)
+					if next < 0 {
+						break
+					}
+					idx = idx + len(kw) + next
+					continue
+				}
+			}
+
+			// Check word boundary after keyword
+			end := idx + len(kw)
+			if end < len(upperSanitized) {
+				next := upperSanitized[end]
+				if next != ' ' && next != '\n' && next != '\t' && next != '(' {
+					nextIdx := strings.Index(upperSanitized[end:], kw)
+					if nextIdx < 0 {
+						break
+					}
+					idx = end + nextIdx
+					continue
+				}
+			}
+
+			rest := strings.TrimSpace(sanitized[end:])
+			if len(rest) == 0 {
+				break
+			}
+
+			// Skip subqueries: FROM (SELECT ...)
+			if rest[0] == '(' {
+				next := strings.Index(upperSanitized[end:], kw)
+				if next < 0 {
+					break
+				}
+				idx = end + next
+				continue
+			}
+
+			name := extractIdentifier(rest)
+			if name == "" {
+				next := strings.Index(upperSanitized[end:], kw)
+				if next < 0 {
+					break
+				}
+				idx = end + next
+				continue
+			}
+
+			// Remove schema prefix
+			parts := strings.Split(name, ".")
+			final := parts[len(parts)-1]
+			final = stripQuotes(final)
+			t := strings.ToLower(final)
+
+			// Skip SQL keywords that may follow FROM (e.g., FROM (SELECT ...))
+			upperT := strings.ToUpper(t)
+			if upperT != "SELECT" && upperT != "LATERAL" && upperT != "UNNEST" && upperT != "GENERATE_SERIES" {
+				tables = append(tables, t)
+			}
+
+			next := strings.Index(upperSanitized[end:], kw)
+			if next < 0 {
+				break
+			}
+			idx = end + next
+		}
+	}
+
+	return tables
+}
+
 // ExtractTables extracts table names from write queries.
 // Handles multi-statement queries, CTE (WITH ... AS (UPDATE ...)), and subqueries.
 func ExtractTables(query string) []string {

--- a/internal/router/parser_ast.go
+++ b/internal/router/parser_ast.go
@@ -150,6 +150,33 @@ func ExtractTablesAST(query string) []string {
 	return tables
 }
 
+// ExtractReadTablesAST extracts table names from read queries using AST parsing.
+// Collects all RangeVar references from SELECT statements (FROM, JOIN clauses).
+// Falls back to string-based ExtractReadTables on parse errors.
+func ExtractReadTablesAST(query string) []string {
+	tree, err := ParseSQL(query)
+	if err != nil {
+		slog.Debug("AST parse failed for read table extraction, fallback", "error", err)
+		return ExtractReadTables(query)
+	}
+
+	seen := make(map[string]bool)
+	var tables []string
+
+	WalkNodes(tree, func(node *pg_query.Node) bool {
+		if rv := node.GetRangeVar(); rv != nil {
+			t := strings.ToLower(rv.GetRelname())
+			if t != "" && !seen[t] {
+				seen[t] = true
+				tables = append(tables, t)
+			}
+		}
+		return true
+	})
+
+	return tables
+}
+
 // extractWriteTables collects table names from write operations.
 func extractWriteTables(node *pg_query.Node, add func(string)) {
 	switch n := node.GetNode().(type) {

--- a/internal/router/parser_ast_test.go
+++ b/internal/router/parser_ast_test.go
@@ -237,6 +237,65 @@ func TestClassifyAST_DollarQuotingHintInjection(t *testing.T) {
 	}
 }
 
+func TestExtractReadTablesAST(t *testing.T) {
+	tests := []struct {
+		name string
+		query string
+		want []string
+	}{
+		{
+			"simple select",
+			"SELECT * FROM users",
+			[]string{"users"},
+		},
+		{
+			"select with join",
+			"SELECT * FROM users JOIN orders ON users.id = orders.user_id",
+			[]string{"users", "orders"},
+		},
+		{
+			"select with schema",
+			"SELECT * FROM public.users",
+			[]string{"users"},
+		},
+		{
+			"select with left join",
+			"SELECT u.name, o.total FROM users u LEFT JOIN orders o ON u.id = o.user_id",
+			[]string{"users", "orders"},
+		},
+		{
+			"select with subquery",
+			"SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)",
+			[]string{"users", "orders"},
+		},
+		{
+			"CTE read",
+			"WITH active AS (SELECT * FROM users WHERE active = true) SELECT * FROM active JOIN orders ON active.id = orders.user_id",
+			[]string{"active", "orders", "users"}, // CTE alias included as RangeVar; harmless for invalidation
+		},
+		{
+			"write query returns empty or write tables only",
+			"INSERT INTO users VALUES (1)",
+			[]string{"users"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tables := ExtractReadTablesAST(tt.query)
+			if len(tables) != len(tt.want) {
+				t.Errorf("ExtractReadTablesAST(%q) got %d tables %v, want %d %v", tt.query, len(tables), tables, len(tt.want), tt.want)
+				return
+			}
+			for i, w := range tt.want {
+				if tables[i] != w {
+					t.Errorf("tables[%d] = %q, want %q", i, tables[i], w)
+				}
+			}
+		})
+	}
+}
+
 func TestExtractTablesAST_QuotedNames(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/router/parser_test.go
+++ b/internal/router/parser_test.go
@@ -139,6 +139,70 @@ func TestExtractTables(t *testing.T) {
 	}
 }
 
+func TestExtractReadTables(t *testing.T) {
+	tests := []struct {
+		name string
+		query string
+		want []string
+	}{
+		{
+			"simple select",
+			"SELECT * FROM users",
+			[]string{"users"},
+		},
+		{
+			"lowercase select",
+			"select * from orders",
+			[]string{"orders"},
+		},
+		{
+			"select with schema",
+			"SELECT * FROM public.users",
+			[]string{"users"},
+		},
+		{
+			"select with join",
+			"SELECT * FROM users JOIN orders ON users.id = orders.user_id",
+			[]string{"users", "orders"},
+		},
+		{
+			"select with left join",
+			"SELECT * FROM users LEFT JOIN orders ON users.id = orders.user_id",
+			[]string{"users", "orders"},
+		},
+		{
+			"select with multiple joins",
+			"SELECT * FROM users JOIN orders ON users.id = orders.user_id JOIN products ON orders.product_id = products.id",
+			[]string{"users", "orders", "products"},
+		},
+		{
+			"write query returns empty",
+			"INSERT INTO users VALUES (1)",
+			nil,
+		},
+		{
+			"update query returns empty",
+			"UPDATE users SET name = 'a'",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tables := ExtractReadTables(tt.query)
+			if len(tables) != len(tt.want) {
+				t.Errorf("ExtractReadTables(%q) got %d tables %v, want %d %v", tt.query, len(tables), tables, len(tt.want), tt.want)
+				return
+			}
+			for i, w := range tt.want {
+				if tables[i] != w {
+					t.Errorf("tables[%d] = %q, want %q", i, tables[i], w)
+				}
+			}
+		})
+	}
+}
+
 // === QA Report Regression Tests (extended cases) ===
 
 // #4: Dollar Quoting — additional cases beyond dollar_quote_test.go


### PR DESCRIPTION
## 변경 사항
- `ExtractReadTables()` (string-based), `ExtractReadTablesAST()` (AST-based) 함수 추가
- `proxy/helpers.go`에 `extractReadQueryTables()` 헬퍼 추가
- `query_read.go`, `query_extended.go`의 `cache.Set()` 호출에 테이블 메타데이터 전달 (nil → 실제 테이블명)
- 캐시 무효화 테스트 2건, 테이블 추출 테스트 15건 추가

## 테스트
- `go test ./internal/router/...` 전체 통과
- `go test ./internal/cache/...` 전체 통과
- 쓰기 후 해당 테이블 캐시 즉시 무효화 확인
- 무관한 테이블 캐시는 유지 확인

closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)