### PR TITLE
fix(admin): /admin/health 백엔드 검사 병렬화 (#146)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -63,6 +63,8 @@ func (s *Server) ListenAndServe(addr string) error {
 }
 
 // handleHealth returns the health status of all backends.
+// All backend TCP checks run concurrently so that total latency is bounded
+// by a single check timeout (~2 s) regardless of backend count.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -77,16 +79,33 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writerAddr := fmt.Sprintf("%s:%d", cfg.Writer.Host, cfg.Writer.Port)
-	writerHealthy := checkTCP(writerAddr)
 
-	readers := make([]backendHealth, 0, len(cfg.Readers))
-	for _, r := range cfg.Readers {
-		addr := fmt.Sprintf("%s:%d", r.Host, r.Port)
-		readers = append(readers, backendHealth{
-			Addr:    addr,
-			Healthy: checkTCP(addr),
-		})
+	// Pre-allocate readers slice so each goroutine writes to its own index.
+	readers := make([]backendHealth, len(cfg.Readers))
+	for i, rd := range cfg.Readers {
+		readers[i].Addr = fmt.Sprintf("%s:%d", rd.Host, rd.Port)
 	}
+
+	var wg sync.WaitGroup
+	var writerHealthy bool
+
+	// Check writer concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		writerHealthy = checkTCP(writerAddr)
+	}()
+
+	// Check all readers concurrently.
+	for i := range readers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			readers[idx].Healthy = checkTCP(readers[idx].Addr)
+		}(i)
+	}
+
+	wg.Wait()
 
 	resp := map[string]any{
 		"writer":  backendHealth{Addr: writerAddr, Healthy: writerHealthy},

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -276,5 +277,174 @@ func TestHandleReload_MethodNotAllowed(t *testing.T) {
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleHealth_ParallelTiming(t *testing.T) {
+	// All backends point to a non-routable address (RFC 5737 TEST-NET)
+	// to trigger the 2 s dial timeout. With 3 backends checked
+	// sequentially this would take ~6 s; parallel should finish in ~2 s.
+	cfg := &config.Config{
+		Writer: config.DBConfig{Host: "192.0.2.1", Port: 9999},
+		Readers: []config.DBConfig{
+			{Host: "192.0.2.1", Port: 9999},
+			{Host: "192.0.2.1", Port: 9999},
+		},
+	}
+
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return nil },
+		func() *cache.Invalidator { return nil },
+		func() *pool.Pool { return nil },
+		func() map[string]*pool.Pool { return nil },
+		func() *audit.Logger { return nil },
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/health", nil)
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	srv.handleHealth(w, req)
+	elapsed := time.Since(start)
+
+	// Sequential would take ~6 s. Parallel should finish in ~2 s.
+	// Use 4 s as threshold to allow margin without flakiness.
+	if elapsed > 4*time.Second {
+		t.Errorf("health check took %v; expected < 4 s (parallel execution)", elapsed)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	writer := resp["writer"].(map[string]any)
+	if writer["healthy"] != false {
+		t.Error("writer should be unhealthy")
+	}
+	readers := resp["readers"].([]any)
+	if len(readers) != 2 {
+		t.Fatalf("expected 2 readers, got %d", len(readers))
+	}
+}
+
+func TestHandleHealth_LiveBackends(t *testing.T) {
+	// Start a real TCP listener so checkTCP succeeds.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	lnAddr := ln.Addr().(*net.TCPAddr)
+	cfg := &config.Config{
+		Writer: config.DBConfig{Host: "127.0.0.1", Port: lnAddr.Port},
+		Readers: []config.DBConfig{
+			{Host: "127.0.0.1", Port: lnAddr.Port},
+			{Host: "127.0.0.1", Port: lnAddr.Port},
+		},
+	}
+
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return nil },
+		func() *cache.Invalidator { return nil },
+		func() *pool.Pool { return nil },
+		func() map[string]*pool.Pool { return nil },
+		func() *audit.Logger { return nil },
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/health", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	writer := resp["writer"].(map[string]any)
+	if writer["healthy"] != true {
+		t.Error("writer should be healthy")
+	}
+	readers := resp["readers"].([]any)
+	if len(readers) != 2 {
+		t.Fatalf("expected 2 readers, got %d", len(readers))
+	}
+	for i, r := range readers {
+		rd := r.(map[string]any)
+		if rd["healthy"] != true {
+			t.Errorf("reader[%d] should be healthy", i)
+		}
+	}
+}
+
+func TestHandleHealth_NoReaders(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	lnAddr := ln.Addr().(*net.TCPAddr)
+	cfg := &config.Config{
+		Writer:  config.DBConfig{Host: "127.0.0.1", Port: lnAddr.Port},
+		Readers: nil,
+	}
+
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return nil },
+		func() *cache.Invalidator { return nil },
+		func() *pool.Pool { return nil },
+		func() map[string]*pool.Pool { return nil },
+		func() *audit.Logger { return nil },
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/health", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	writer := resp["writer"].(map[string]any)
+	if writer["healthy"] != true {
+		t.Error("writer should be healthy")
+	}
+	readers := resp["readers"].([]any)
+	if len(readers) != 0 {
+		t.Errorf("expected 0 readers, got %d", len(readers))
 	}
 }


### PR DESCRIPTION
## 변경 사항
- `handleHealth()` 내 writer + readers TCP 검사를 goroutine + `sync.WaitGroup`으로 병렬화
- 전체 응답 시간이 백엔드 수와 무관하게 ~2초 이내로 바운딩
- JSON 응답 형식 변경 없음

## 테스트
- `go test ./internal/admin/...` 전체 통과
- `TestHandleHealth_ParallelTiming` — 3개 백엔드 2s 타임아웃, 순차 시 ~6초 → 병렬 ~2초 확인
- `TestHandleHealth_LiveBackends` — 실제 TCP 리스너로 정상 응답 검증
- `TestHandleHealth_NoReaders` — reader 없는 엣지케이스 검증

closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)