### PR TITLE
fix(router): splitStatements 달러 쿼팅·주석 처리 보강 (#147)

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -117,7 +117,9 @@ func containsTransactionKeyword(query string) bool {
 	return false
 }
 
-// splitStatements splits a query string by semicolons, respecting quoted strings.
+// splitStatements splits a query string by semicolons, respecting quoted strings,
+// dollar quoting ($$...$$, $tag$...$tag$), line comments (-- ...), and
+// block comments (/* ... */ including nested).
 func splitStatements(query string) []string {
 	var stmts []string
 	var current strings.Builder
@@ -126,10 +128,84 @@ func splitStatements(query string) []string {
 
 	for i := 0; i < len(query); i++ {
 		ch := query[i]
+
+		// --- Dollar quoting (only outside regular quotes) ---
+		if ch == '$' && !inSingleQuote && !inDoubleQuote {
+			tag, ok := parseDollarTag(query, i)
+			if ok {
+				// Write opening tag
+				current.WriteString(tag)
+				// Find closing tag
+				end := strings.Index(query[i+len(tag):], tag)
+				if end >= 0 {
+					// Write body + closing tag
+					current.WriteString(query[i+len(tag) : i+len(tag)+end])
+					current.WriteString(tag)
+					i += len(tag) + end + len(tag) - 1
+				} else {
+					// No closing tag — rest of query is dollar-quoted
+					current.WriteString(query[i+len(tag):])
+					i = len(query) - 1
+				}
+				continue
+			}
+		}
+
+		// --- Line comment: -- (only outside quotes) ---
+		if ch == '-' && !inSingleQuote && !inDoubleQuote &&
+			i+1 < len(query) && query[i+1] == '-' {
+			// Consume until end of line (or end of query)
+			for i < len(query) && query[i] != '\n' {
+				current.WriteByte(query[i])
+				i++
+			}
+			if i < len(query) {
+				current.WriteByte(query[i]) // write the '\n'
+			}
+			continue
+		}
+
+		// --- Block comment: /* ... */ with nesting (only outside quotes) ---
+		if ch == '/' && !inSingleQuote && !inDoubleQuote &&
+			i+1 < len(query) && query[i+1] == '*' {
+			depth := 1
+			current.WriteByte('/')
+			current.WriteByte('*')
+			i += 2
+			for i < len(query) && depth > 0 {
+				if i+1 < len(query) && query[i] == '/' && query[i+1] == '*' {
+					depth++
+					current.WriteByte('/')
+					current.WriteByte('*')
+					i += 2
+				} else if i+1 < len(query) && query[i] == '*' && query[i+1] == '/' {
+					depth--
+					current.WriteByte('*')
+					current.WriteByte('/')
+					i += 2
+				} else {
+					current.WriteByte(query[i])
+					i++
+				}
+			}
+			i-- // outer loop will i++
+			continue
+		}
+
 		switch {
 		case ch == '\'' && !inDoubleQuote:
-			inSingleQuote = !inSingleQuote
 			current.WriteByte(ch)
+			if inSingleQuote {
+				// Check for escaped quote ('')
+				if i+1 < len(query) && query[i+1] == '\'' {
+					current.WriteByte('\'')
+					i++
+				} else {
+					inSingleQuote = false
+				}
+			} else {
+				inSingleQuote = true
+			}
 		case ch == '"' && !inSingleQuote:
 			inDoubleQuote = !inDoubleQuote
 			current.WriteByte(ch)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -289,18 +289,71 @@ func TestSession_ASTParser_PreparedStatement(t *testing.T) {
 
 func TestSplitStatements(t *testing.T) {
 	tests := []struct {
+		name  string
 		query string
 		want  int
 	}{
-		{"SELECT 1", 1},
-		{"SELECT 1; SELECT 2;", 2},
-		{"INSERT INTO t VALUES ('a;b'); SELECT 1;", 2}, // semicolon inside quotes
-		{"", 0},
+		{"simple single", "SELECT 1", 1},
+		{"simple multi", "SELECT 1; SELECT 2;", 2},
+		{"single-quoted semicolon", "INSERT INTO t VALUES ('a;b'); SELECT 1;", 2},
+		{"empty", "", 0},
+		{"escaped single quotes", "SELECT 'it''s;fine'; SELECT 2", 2},
+		{"double-quoted semicolon", `SELECT "col;name" FROM t; SELECT 2`, 2},
+
+		// Dollar quoting
+		{
+			"dollar-quoted function body",
+			"CREATE FUNCTION f() AS $$ BEGIN SELECT 1; END; $$ LANGUAGE plpgsql",
+			1,
+		},
+		{
+			"tagged dollar quote",
+			"SELECT $tag$hello;world$tag$",
+			1,
+		},
+		{
+			"dollar quote then another statement",
+			"CREATE FUNCTION f() AS $$ BEGIN SELECT 1; END; $$ LANGUAGE plpgsql; SELECT 1",
+			2,
+		},
+
+		// Line comments
+		{
+			"line comment with semicolon",
+			"SELECT 1; -- comment; here\nSELECT 2",
+			2,
+		},
+		{
+			"line comment at end",
+			"SELECT 1 -- trailing; comment",
+			1,
+		},
+
+		// Block comments
+		{
+			"block comment with semicolon",
+			"SELECT 1; /* comment; here */ SELECT 2",
+			2,
+		},
+		{
+			"nested block comment with semicolon",
+			"SELECT 1; /* outer /* inner; */ still comment; */ SELECT 2",
+			2,
+		},
+
+		// Mixed
+		{
+			"function with comments",
+			"CREATE FUNCTION f() AS $$ BEGIN\n-- a; comment\nSELECT 1; /* block; */ END; $$ LANGUAGE plpgsql; SELECT 2",
+			2,
+		},
 	}
 	for _, tt := range tests {
-		got := splitStatements(tt.query)
-		if len(got) != tt.want {
-			t.Errorf("splitStatements(%q) = %d stmts %v, want %d", tt.query, len(got), got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitStatements(tt.query)
+			if len(got) != tt.want {
+				t.Errorf("splitStatements(%q) = %d stmts %v, want %d", tt.query, len(got), got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 변경 사항
- `splitStatements()`를 재작성하여 달러 쿼팅(`$$`, `$tag$`), 라인 주석(`--`), 블록 주석(`/* */`, 중첩 포함), 이스케이프된 따옴표(`''`) 정상 처리
- 기존 `parseDollarTag()` 유틸 재사용

## 테스트
- `go test ./internal/router/...` 전체 통과
- 테스트 4건 → 14건으로 확대:
  - 달러 쿼팅 함수 본문 (분리 없음 확인)
  - 태그 달러 쿼팅 (`$tag$...$tag$`)
  - 라인 주석 내 세미콜론
  - 블록 주석 내 세미콜론
  - 중첩 블록 주석
  - 이스케이프 따옴표
  - 복합 시나리오

closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)