### PR TITLE
fix(cache): 캐시 키에 응답 포맷 namespace 추가로 경로 간 충돌 방지

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -43,6 +43,21 @@ func New(cfg Config) *Cache {
 	}
 }
 
+// Cache key namespace constants to prevent cross-path collisions.
+// Different response formats (PG wire, JSON, extended wire) must use
+// different namespaces so the same SQL doesn't return the wrong format.
+const (
+	NSProxyWire uint64 = 0                    // proxy simple query (default)
+	NSDataAPI   uint64 = 0xa5a5a5a5a5a5a5a5  // Data API JSON responses
+	NSExtended  uint64 = 0x5a5a5a5a5a5a5a5a  // extended query wire responses
+)
+
+// WithNamespace mixes a namespace into a cache key to prevent collisions
+// between different response formats sharing the same cache.
+func WithNamespace(key uint64, ns uint64) uint64 {
+	return key ^ ns
+}
+
 // CacheKey generates a hash key from query text and parameters.
 func CacheKey(query string, params ...any) uint64 {
 	h := fnv.New64a()

--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/jyukki97/pgmux/internal/cache"
 	"github.com/jyukki97/pgmux/internal/pool"
 	"github.com/jyukki97/pgmux/internal/protocol"
 	"github.com/jyukki97/pgmux/internal/router"
@@ -105,7 +106,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		// Cache the response keyed by the batch (first Parse query), skip if oversize
 		if collected != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
 			_, query := protocol.ParseParseMessage(buf[0].Payload)
-			key := s.cacheKey(query)
+			key := cache.WithNamespace(s.cacheKey(query), cache.NSExtended)
 			tables := s.extractReadQueryTables(query)
 			s.queryCache.Set(key, collected, tables)
 			if s.metrics != nil {


### PR DESCRIPTION
## 변경 사항

- `cache.go`: namespace 상수(`NSProxyWire`, `NSDataAPI`, `NSExtended`)와 `WithNamespace` 헬퍼 추가
- `query_extended.go`: extended query 캐시 SET에 `NSExtended` 적용
- `handler.go`: Data API 캐시 GET/SET에 `NSDataAPI` 적용

동일 SQL이 Data API(JSON), proxy simple read(PG wire), extended query(extended wire) 경로에서 각각 독립된 캐시 키를 사용하여 응답 포맷 충돌을 방지합니다.

## 테스트

- `go build ./...` 통과

closes #153