### PR TITLE
fix(dataapi): 읽기 캐시 저장 시 read table extractor 사용

### DIFF
--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -230,7 +230,7 @@ func (s *Server) executeRead(ctx context.Context, sql string, pq *router.ParsedQ
 	// Cache lookup span
 	_, cacheLookupSpan := telemetry.Tracer().Start(ctx, "pgmux.cache.lookup")
 	if queryCache != nil {
-		key := s.cacheKeyParsed(sql, pq)
+		key := cache.WithNamespace(s.cacheKeyParsed(sql, pq), cache.NSDataAPI)
 		if cached := queryCache.Get(key); cached != nil {
 			if s.met != nil {
 				s.met.CacheHits.Inc()
@@ -278,9 +278,9 @@ func (s *Server) executeRead(ctx context.Context, sql string, pq *router.ParsedQ
 	// Cache store span
 	if queryCache != nil && resp != nil {
 		_, storeSpan := telemetry.Tracer().Start(ctx, "pgmux.cache.store")
-		key := s.cacheKeyParsed(sql, pq)
+		key := cache.WithNamespace(s.cacheKeyParsed(sql, pq), cache.NSDataAPI)
 		if data, err := json.Marshal(resp); err == nil {
-			tables := s.extractTablesParsed(sql, pq)
+			tables := s.extractReadTablesParsed(sql, pq)
 			queryCache.Set(key, data, tables)
 			if s.met != nil {
 				s.met.CacheEntries.Set(float64(queryCache.Len()))
@@ -689,6 +689,20 @@ func (s *Server) extractTablesParsed(sql string, pq *router.ParsedQuery) []strin
 		return router.ExtractTablesASTWithTree(pq)
 	}
 	return s.extractTables(sql)
+}
+
+func (s *Server) extractReadTables(sql string) []string {
+	if s.cfgFn().Routing.ASTParser {
+		return router.ExtractReadTablesAST(sql)
+	}
+	return router.ExtractReadTables(sql)
+}
+
+func (s *Server) extractReadTablesParsed(sql string, pq *router.ParsedQuery) []string {
+	if s.cfgFn().Routing.ASTParser && pq != nil {
+		return router.ExtractReadTablesASTWithTree(pq)
+	}
+	return s.extractReadTables(sql)
 }
 
 // truncateSQL returns the first 100 characters of a SQL statement for span attributes.

--- a/internal/router/parser_ast.go
+++ b/internal/router/parser_ast.go
@@ -188,6 +188,16 @@ func ExtractReadTablesAST(query string) []string {
 		return ExtractReadTables(query)
 	}
 
+	return extractReadTablesFromTree(tree)
+}
+
+// ExtractReadTablesASTWithTree extracts read table names using a pre-parsed AST tree.
+func ExtractReadTablesASTWithTree(pq *ParsedQuery) []string {
+	return extractReadTablesFromTree(pq.Tree)
+}
+
+// extractReadTablesFromTree collects all RangeVar references from a parse tree.
+func extractReadTablesFromTree(tree *pg_query.ParseResult) []string {
 	seen := make(map[string]bool)
 	var tables []string
 


### PR DESCRIPTION
## 변경 사항

- `handler.go`: `executeRead` 캐시 저장에서 `extractTablesParsed` → `extractReadTablesParsed` 변경
- `handler.go`: `extractReadTables`, `extractReadTablesParsed` 메서드 추가
- `parser_ast.go`: `ExtractReadTablesASTWithTree`, `extractReadTablesFromTree` 함수 추가

SELECT 쿼리의 FROM/JOIN 테이블을 올바르게 추출하여 write 발생 시 캐시가 정상 무효화됩니다.

## 테스트

- `go build ./...` 통과

closes #154