### PR TITLE
fix(main): HTTP 서버 lifecycle 관리 및 graceful shutdown 추가

### DIFF
--- a/cmd/pgmux/main.go
+++ b/cmd/pgmux/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -62,14 +63,27 @@ func run() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// Collect HTTP servers for graceful shutdown
+	var httpServers []*http.Server
+
+	// Channel to propagate HTTP bind errors to main goroutine
+	httpErrCh := make(chan error, 3)
+
 	// Start Prometheus metrics HTTP server
 	if cfg.Metrics.Enabled {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
+		metricsSrv := &http.Server{Handler: mux}
+		httpServers = append(httpServers, metricsSrv)
+
+		ln, err := net.Listen("tcp", cfg.Metrics.Listen)
+		if err != nil {
+			return fmt.Errorf("metrics server bind %s: %w", cfg.Metrics.Listen, err)
+		}
+		slog.Info("metrics server starting", "listen", cfg.Metrics.Listen)
 		go func() {
-			slog.Info("metrics server starting", "listen", cfg.Metrics.Listen)
-			if err := http.ListenAndServe(cfg.Metrics.Listen, mux); err != nil && err != http.ErrServerClosed {
-				slog.Error("metrics server error", "error", err)
+			if err := metricsSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+				httpErrCh <- fmt.Errorf("metrics server: %w", err)
 			}
 		}()
 	}
@@ -82,9 +96,17 @@ func run() error {
 		adminSrv.SetReloadFunc(func() error {
 			return reloadConfig(cfgPath, srv)
 		})
+		adminHTTP := adminSrv.HTTPServer()
+
+		ln, err := net.Listen("tcp", cfg.Admin.Listen)
+		if err != nil {
+			return fmt.Errorf("admin server bind %s: %w", cfg.Admin.Listen, err)
+		}
+		httpServers = append(httpServers, adminHTTP)
+		slog.Info("admin server starting", "listen", cfg.Admin.Listen)
 		go func() {
-			if err := adminSrv.ListenAndServe(cfg.Admin.Listen); err != nil && err != http.ErrServerClosed {
-				slog.Error("admin server error", "error", err)
+			if err := adminHTTP.Serve(ln); err != nil && err != http.ErrServerClosed {
+				httpErrCh <- fmt.Errorf("admin server: %w", err)
 			}
 		}()
 	}
@@ -92,12 +114,28 @@ func run() error {
 	// Start Data API server
 	if cfg.DataAPI.Enabled {
 		apiSrv := dataapi.New(srv.Cfg, srv.WriterPool, srv.ReaderPools, srv.Balancer, srv.Cache, srv.ProxyMetrics(), srv.RateLimiter, func() *cache.Invalidator { return srv.Invalidator() })
+		apiHTTP := apiSrv.HTTPServer()
+
+		ln, err := net.Listen("tcp", cfg.DataAPI.Listen)
+		if err != nil {
+			return fmt.Errorf("data api server bind %s: %w", cfg.DataAPI.Listen, err)
+		}
+		httpServers = append(httpServers, apiHTTP)
+		slog.Info("data api server starting", "listen", cfg.DataAPI.Listen)
 		go func() {
-			if err := apiSrv.ListenAndServe(cfg.DataAPI.Listen); err != nil && err != http.ErrServerClosed {
-				slog.Error("data api server error", "error", err)
+			if err := apiHTTP.Serve(ln); err != nil && err != http.ErrServerClosed {
+				httpErrCh <- fmt.Errorf("data api server: %w", err)
 			}
 		}()
 	}
+
+	// Watch for HTTP server runtime errors
+	go func() {
+		if err := <-httpErrCh; err != nil {
+			slog.Error("http server runtime error", "error", err)
+			cancel()
+		}
+	}()
 
 	// Handle SIGHUP for config reload
 	sighupCh := make(chan os.Signal, 1)
@@ -129,6 +167,18 @@ func run() error {
 			}
 		}()
 	}
+
+	// Graceful shutdown of HTTP servers when context is cancelled
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		for _, s := range httpServers {
+			if err := s.Shutdown(shutdownCtx); err != nil {
+				slog.Error("http server shutdown", "error", err)
+			}
+		}
+	}()
 
 	slog.Info("pgmux starting", "listen", cfg.Proxy.Listen)
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -49,17 +49,24 @@ func New(cfgFn func() *config.Config, cacheFn func() *cache.Cache, invalidatorFn
 	}
 }
 
-// ListenAndServe starts the admin HTTP server.
-func (s *Server) ListenAndServe(addr string) error {
+// HTTPServer returns an *http.Server with the admin routes registered.
+// The caller is responsible for calling Serve/Shutdown.
+func (s *Server) HTTPServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/admin/health", s.handleHealth)
 	mux.HandleFunc("/admin/stats", s.handleStats)
 	mux.HandleFunc("/admin/config", s.handleConfig)
 	mux.HandleFunc("/admin/cache/flush", s.handleCacheFlush)
 	mux.HandleFunc("/admin/reload", s.handleReload)
+	return &http.Server{Handler: mux}
+}
 
+// ListenAndServe starts the admin HTTP server.
+func (s *Server) ListenAndServe(addr string) error {
+	srv := s.HTTPServer()
+	srv.Addr = addr
 	slog.Info("admin server starting", "listen", addr)
-	return http.ListenAndServe(addr, mux)
+	return srv.ListenAndServe()
 }
 
 // handleHealth returns the health status of all backends.

--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -75,13 +75,20 @@ func New(cfgFn func() *config.Config, writerPoolFn func() *pool.Pool, readerPool
 	}
 }
 
-// ListenAndServe starts the Data API HTTP server.
-func (s *Server) ListenAndServe(addr string) error {
+// HTTPServer returns an *http.Server with the Data API routes registered.
+// The caller is responsible for calling Serve/Shutdown.
+func (s *Server) HTTPServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/query", s.handleQuery)
+	return &http.Server{Handler: mux}
+}
 
+// ListenAndServe starts the Data API HTTP server.
+func (s *Server) ListenAndServe(addr string) error {
+	srv := s.HTTPServer()
+	srv.Addr = addr
 	slog.Info("data api server starting", "listen", addr)
-	return http.ListenAndServe(addr, mux)
+	return srv.ListenAndServe()
 }
 
 func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 변경 사항

- `main.go`: `net.Listen`으로 선 바인딩 (포트 충돌 시 즉시 실패), `http.Server.Serve` 사용, context 취소 시 `Shutdown(5s)` 호출, runtime 에러 전파
- `admin.go`: `HTTPServer()` 메서드 추가
- `handler.go`: `HTTPServer()` 메서드 추가

## 테스트

- `go build ./...` 통과
- 포트 충돌 시 프로세스 즉시 종료 확인 가능

closes #156