### PR TITLE
fix(router): hot reload 시 기존 backend healthy/replayLSN 상태 보존

### DIFF
--- a/internal/router/balancer.go
+++ b/internal/router/balancer.go
@@ -101,14 +101,32 @@ func (r *RoundRobin) checkBackends() {
 	}
 }
 
-// UpdateBackends replaces the backend list atomically.
+// UpdateBackends replaces the backend list atomically, preserving
+// healthy and replayLSN state for backends that already exist.
 func (r *RoundRobin) UpdateBackends(addrs []string) {
+	// Snapshot existing backends under read lock.
+	r.mu.RLock()
+	old := r.backends
+	r.mu.RUnlock()
+
+	// Build addr → *Backend map from the current list.
+	existing := make(map[string]*Backend, len(old))
+	for _, b := range old {
+		existing[b.Addr] = b
+	}
+
+	// Build new slice, reusing existing backends to preserve runtime state.
 	backends := make([]*Backend, len(addrs))
 	for i, addr := range addrs {
-		b := &Backend{Addr: addr}
-		b.healthy.Store(true)
-		backends[i] = b
+		if b, ok := existing[addr]; ok {
+			backends[i] = b
+		} else {
+			b := &Backend{Addr: addr}
+			b.healthy.Store(true)
+			backends[i] = b
+		}
 	}
+
 	r.mu.Lock()
 	r.backends = backends
 	r.mu.Unlock()


### PR DESCRIPTION
## 변경 사항

- `balancer.go`: `UpdateBackends`에서 기존 backend의 healthy/replayLSN 상태를 보존
  - 기존 addr → Backend 맵을 빌드하여 상태 복사
  - 새로 추가된 backend은 healthy=true, replayLSN=0으로 초기화
  - 제거된 backend은 자연스럽게 드롭

reload 직후 죽어있던 reader가 잠시 선택되거나, replayLSN=0으로 리셋되어 causal consistency read가 writer로 몰리는 문제를 해결합니다.

## 테스트

- `go build ./...` 통과

closes #155