### PR TITLE
refactor: dead code 정리 (미사용 함수 제거)

### DIFF
--- a/internal/cache/normalize.go
+++ b/internal/cache/normalize.go
@@ -40,31 +40,3 @@ func semanticCacheKeyFromTree(tree *pg_query.ParseResult, query string) uint64 {
 	return h.Sum64()
 }
 
-// NormalizeQuery returns a canonical string representation of the query
-// with constants replaced by $N placeholders. Useful for logging and debugging.
-func NormalizeQuery(query string) string {
-	normalized, err := pg_query.Normalize(query)
-	if err != nil {
-		return query
-	}
-	return normalized
-}
-
-// SemanticCacheKeyWithParams generates a semantic cache key that also considers
-// the actual parameter values. This allows caching different results for
-// the same query structure with different parameters.
-func SemanticCacheKeyWithParams(query string, params ...any) uint64 {
-	normalized, err := pg_query.Normalize(query)
-	if err != nil {
-		return CacheKey(query, params...)
-	}
-
-	h := fnv.New64a()
-	h.Write([]byte(normalized))
-	for _, p := range params {
-		if s, ok := p.(string); ok {
-			h.Write([]byte(s))
-		}
-	}
-	return h.Sum64()
-}

--- a/internal/cache/normalize_test.go
+++ b/internal/cache/normalize_test.go
@@ -46,45 +46,6 @@ func TestSemanticCacheKey_FallbackOnError(t *testing.T) {
 	}
 }
 
-func TestNormalizeQuery(t *testing.T) {
-	tests := []struct {
-		query string
-		want  string
-	}{
-		{"SELECT * FROM users WHERE id = 1", "SELECT * FROM users WHERE id = $1"},
-		{"SELECT * FROM users WHERE name = 'alice'", "SELECT * FROM users WHERE name = $1"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			got := NormalizeQuery(tt.query)
-			if got != tt.want {
-				t.Errorf("NormalizeQuery(%q) = %q, want %q", tt.query, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSemanticCacheKeyWithParams(t *testing.T) {
-	// Same normalized query + same params → same key
-	k1 := SemanticCacheKeyWithParams("SELECT * FROM users WHERE id = 1")
-	k2 := SemanticCacheKeyWithParams("SELECT * FROM users WHERE id = 2")
-
-	// Normalized form is the same (both become "SELECT * FROM users WHERE id = $1")
-	// but without explicit params, the keys should be the same
-	if k1 != k2 {
-		t.Errorf("same normalized form without params: key1 (%d) != key2 (%d)", k1, k2)
-	}
-
-	// With explicit params, different values → different keys
-	k3 := SemanticCacheKeyWithParams("SELECT * FROM users WHERE id = $1", "1")
-	k4 := SemanticCacheKeyWithParams("SELECT * FROM users WHERE id = $1", "2")
-
-	if k3 == k4 {
-		t.Error("different params should produce different keys")
-	}
-}
-
 func TestSemanticCacheKeyWithTree_MatchesSemanticCacheKey(t *testing.T) {
 	queries := []string{
 		"SELECT * FROM users WHERE id = 1",

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -216,20 +216,6 @@ func (p *Pool) newConn() (*Conn, error) {
 	return c, nil
 }
 
-// Ping checks if a connection is still alive.
-func Ping(conn *Conn) error {
-	conn.Conn.SetDeadline(time.Now().Add(time.Second))
-	defer conn.Conn.SetDeadline(time.Time{})
-
-	// Write a single null byte and see if connection errors
-	one := make([]byte, 0)
-	_, err := conn.Conn.Read(one)
-	if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
-		return nil // timeout is expected — connection is alive
-	}
-	return err
-}
-
 // StartHealthCheck runs a periodic health check goroutine.
 func (p *Pool) StartHealthCheck(ctx context.Context, interval time.Duration) {
 	go func() {

--- a/internal/proxy/query_read.go
+++ b/internal/proxy/query_read.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jyukki97/pgmux/internal/telemetry"
 )
 
-// handleReadQueryTraced wraps handleReadQuery with OpenTelemetry child spans for
+// handleReadQueryTraced handles read queries with OpenTelemetry child spans for
 // cache lookup, pool acquire, backend exec, and cache store.
 func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session, ct *cancelTarget, pq *router.ParsedQuery) error {
 	// Cache lookup span
@@ -156,124 +156,6 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		ct.clear()
 		rPool.Release(rConn)
 		execSpan.End()
-	}
-
-	if cb, ok := s.getReaderCB(readerAddr); ok {
-		cb.RecordSuccess()
-	}
-	return nil
-}
-
-// handleReadQuery checks cache, acquires a reader from pool, or falls back to writer.
-func (s *Server) handleReadQuery(ctx context.Context, clientConn net.Conn, msg *protocol.Message, query string, session *router.Session, ct *cancelTarget) error {
-	// Check cache
-	if s.queryCache != nil {
-		key := s.cacheKey(query)
-		if cached := s.queryCache.Get(key); cached != nil {
-			slog.Debug("cache hit", "sql", query)
-			if s.metrics != nil {
-				s.metrics.CacheHits.Inc()
-			}
-			_, err := clientConn.Write(cached)
-			return err
-		}
-		if s.metrics != nil {
-			s.metrics.CacheMisses.Inc()
-		}
-	}
-
-	// Try to acquire a reader connection from pool
-	var readerAddr string
-	if s.getConfig().Routing.CausalConsistency {
-		minLSN := session.LastWriteLSN()
-		readerAddr = s.balancer.NextWithLSN(minLSN)
-	} else {
-		readerAddr = s.balancer.Next()
-	}
-	if readerAddr == "" {
-		slog.Warn("no healthy reader, fallback to writer")
-		if s.metrics != nil {
-			s.metrics.ReaderFallback.Inc()
-		}
-		return s.fallbackToWriter(ctx, clientConn, msg, ct)
-	}
-
-	// Circuit breaker check for reader
-	if cb, ok := s.getReaderCB(readerAddr); ok {
-		if err := cb.Allow(); err != nil {
-			slog.Warn("reader circuit breaker open, fallback to writer", "addr", readerAddr)
-			if s.metrics != nil {
-				s.metrics.ReaderFallback.Inc()
-			}
-			return s.fallbackToWriter(ctx, clientConn, msg, ct)
-		}
-	}
-
-	rPool, ok := s.getReaderPool(readerAddr)
-	if !ok {
-		slog.Warn("no pool for reader, fallback to writer", "addr", readerAddr)
-		if s.metrics != nil {
-			s.metrics.ReaderFallback.Inc()
-		}
-		return s.fallbackToWriter(ctx, clientConn, msg, ct)
-	}
-
-	acquireStart := time.Now()
-	rConn, err := rPool.Acquire(ctx)
-	if err != nil {
-		slog.Warn("acquire reader failed, fallback to writer", "addr", readerAddr, "error", err)
-		if s.metrics != nil {
-			s.metrics.ReaderFallback.Inc()
-		}
-		if cb, ok := s.getReaderCB(readerAddr); ok {
-			cb.RecordFailure()
-		}
-		return s.fallbackToWriter(ctx, clientConn, msg, ct)
-	}
-	if s.metrics != nil {
-		s.metrics.PoolAcquires.WithLabelValues("reader", readerAddr).Inc()
-		s.metrics.PoolAcquireDur.WithLabelValues("reader", readerAddr).Observe(time.Since(acquireStart).Seconds())
-	}
-
-	ct.setFromConn(readerAddr, rConn)
-
-	// Forward query to reader
-	if err := protocol.WriteMessage(rConn, msg.Type, msg.Payload); err != nil {
-		ct.clear()
-		slog.Error("forward to reader", "addr", readerAddr, "error", err)
-		rPool.Discard(rConn)
-		// Fallback to writer
-		return s.fallbackToWriter(ctx, clientConn, msg, ct)
-	}
-
-	// Relay response and collect bytes for caching
-	if s.queryCache != nil {
-		collected, err := s.relayAndCollect(clientConn, rConn)
-		ct.clear()
-		rPool.Release(rConn)
-		if err != nil {
-			return fmt.Errorf("relay reader response: %w", err)
-		}
-		if collected != nil { // nil means oversize, skip cache
-			key := s.cacheKey(query)
-			tables := s.extractReadQueryTables(query)
-			s.queryCache.Set(key, collected, tables)
-			if s.metrics != nil {
-				s.metrics.CacheEntries.Set(float64(s.queryCache.Len()))
-			}
-			slog.Debug("cache set", "sql", query, "size", len(collected))
-		}
-	} else {
-		if err := s.relayUntilReady(clientConn, rConn); err != nil {
-			ct.clear()
-			rPool.Discard(rConn)
-			if cb, ok := s.getReaderCB(readerAddr); ok {
-				cb.RecordFailure()
-			}
-			return fmt.Errorf("relay reader response: %w", err)
-		}
-		ct.clear()
-		rPool.Release(rConn)
 	}
 
 	if cb, ok := s.getReaderCB(readerAddr); ok {

--- a/internal/router/balancer.go
+++ b/internal/router/balancer.go
@@ -171,18 +171,6 @@ func (r *RoundRobin) SetReplayLSN(addr string, lsn LSN) {
 	}
 }
 
-// ReplayLSN returns the replay LSN for a backend.
-func (r *RoundRobin) ReplayLSN(addr string) LSN {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	for _, b := range r.backends {
-		if b.Addr == addr {
-			return LSN(b.replayLSN.Load())
-		}
-	}
-	return InvalidLSN
-}
-
 // Backends returns the list of backend addresses.
 func (r *RoundRobin) Backends() []string {
 	r.mu.RLock()

--- a/internal/router/balancer_test.go
+++ b/internal/router/balancer_test.go
@@ -140,20 +140,6 @@ func TestRoundRobin_NextWithLSN_SkipsUnhealthy(t *testing.T) {
 	}
 }
 
-func TestRoundRobin_SetReplayLSN(t *testing.T) {
-	rb := NewRoundRobin([]string{"a:1", "b:2"})
-
-	rb.SetReplayLSN("a:1", LSN(12345))
-	if got := rb.ReplayLSN("a:1"); got != LSN(12345) {
-		t.Errorf("ReplayLSN(a:1) = %d, want 12345", got)
-	}
-
-	// Unknown addr returns InvalidLSN
-	if got := rb.ReplayLSN("unknown:1"); got != InvalidLSN {
-		t.Errorf("ReplayLSN(unknown) = %d, want 0", got)
-	}
-}
-
 func TestRoundRobin_Backends(t *testing.T) {
 	rb := NewRoundRobin([]string{"a:1", "b:2", "c:3"})
 	addrs := rb.Backends()


### PR DESCRIPTION
## 변경 사항
- 프로덕션 미사용 함수 5건 제거 (-226줄, 기능 변경 없음)
  - `handleReadQuery` (proxy/query_read.go) — `handleReadQueryTraced`가 완전 대체한 중복 구현
  - `Ping` (pool/pool.go) — 호출처 없음
  - `ReplayLSN` (router/balancer.go) — 테스트 전용 getter
  - `NormalizeQuery`, `SemanticCacheKeyWithParams` (cache/normalize.go) — 테스트 전용
- 관련 테스트 3건 정리 (`TestRoundRobin_SetReplayLSN`, `TestNormalizeQuery`, `TestSemanticCacheKeyWithParams`)

## 테스트
- `go build ./...` 성공
- `go test ./internal/cache/ ./internal/router/ ./internal/pool/ ./internal/proxy/` 전부 PASS

closes #163