### PR TITLE
fix(pool): Acquire()에 closed 체크 누락 — Close() 이후 새 연결 생성 가능 (#194)

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -9,6 +9,9 @@ import (
 	"time"
 )
 
+// ErrPoolClosed is returned when Acquire is called on a closed pool.
+var ErrPoolClosed = fmt.Errorf("connection pool: closed")
+
 // BackendKeyHolder is implemented by connections that carry PostgreSQL BackendKeyData.
 type BackendKeyHolder interface {
 	BackendKey() (pid, secret uint32)
@@ -108,6 +111,11 @@ func (p *Pool) Acquire(ctx context.Context) (*Conn, error) {
 
 	for {
 		p.mu.Lock()
+
+		if p.closed {
+			p.mu.Unlock()
+			return nil, ErrPoolClosed
+		}
 
 		// Try to get a valid idle connection
 		for len(p.idle) > 0 {


### PR DESCRIPTION
## 변경 사항

- `pool.Acquire()`의 for 루프 상단(`p.mu.Lock()` 직후)에 `p.closed` 체크 추가
- 패키지 수준 sentinel error `ErrPoolClosed` 추가

## 문제

`Close()`가 `numOpen = 0`과 `p.closed = true`를 설정한 이후에도, 동시 실행 중인 `Acquire()`가 `numOpen < MaxConnections` 조건을 통과하여 새로운 연결을 생성할 수 있었음. 이후 `Release()`가 닫힌 풀에서 `numOpen--`를 수행하면 음수가 되는 race condition 발생.

## 수정

`Acquire()` for 루프에서 mutex를 획득한 직후 `p.closed`를 체크하여, 풀이 닫힌 상태면 즉시 `ErrPoolClosed`를 반환하도록 변경. wait 경로에서 루프 재진입 시에도 동일한 체크를 거치므로 모든 경로가 안전.

## 테스트

- [x] `go build ./...` 컴파일 확인

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)