### PR TITLE
fix(cache): extended protocol 캐시 write-only — read path 누락 (#198)

### DIFF
--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -22,6 +22,23 @@ import (
 
 // handleExtendedRead sends buffered Extended Query messages to a reader, falling back to writer.
 func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string, ct *cancelTarget, dbg *DatabaseGroup, queryTimeout ...time.Duration) error {
+	// Cache lookup — mirror the simple-query read path (query_read.go)
+	if s.queryCache != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
+		_, query := protocol.ParseParseMessage(buf[0].Payload)
+		key := cache.WithNamespace(s.cacheKey(query, dbg.name), cache.NSExtended)
+		if cached := s.queryCache.Get(key); cached != nil {
+			slog.Debug("extended cache hit", "sql", query)
+			if s.metrics != nil {
+				s.metrics.CacheHits.Inc()
+			}
+			_, err := clientConn.Write(cached)
+			return err
+		}
+		if s.metrics != nil {
+			s.metrics.CacheMisses.Inc()
+		}
+	}
+
 	var extTimeout time.Duration
 	if len(queryTimeout) > 0 {
 		extTimeout = queryTimeout[0]


### PR DESCRIPTION
## 변경 사항

- `handleExtendedRead()` 시작 부분에 캐시 조회(Get) 로직 추가
- 첫 번째 Parse 메시지에서 쿼리를 추출하고, `NSExtended` 네임스페이스로 캐시 키를 생성하여 조회
- 캐시 히트 시 백엔드 커넥션 획득 없이 캐시된 응답을 클라이언트에 직접 전송
- CacheHits / CacheMisses 메트릭 반영

기존에는 `relayAndCollect`를 통해 캐시에 저장만 하고 조회하지 않아, LRU 공간만 소비하고 실제 캐시 효과는 없었음. `query_read.go`의 simple query 캐시 조회 패턴을 동일하게 적용.

## 테스트

- [x] `go build ./...` 컴파일 확인
- [ ] extended protocol로 동일 쿼리 2회 실행 시 두 번째에서 캐시 히트 확인
- [ ] `pgmux_cache_hits_total` 메트릭 증가 확인

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)