### PR TITLE
fix(router): reader 장애 시 MarkUnhealthy 미호출로 격리 불가 (#197)

### DIFF
--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -286,6 +286,9 @@ func (s *Server) executeRead(ctx context.Context, sql string, pq *router.ParsedQ
 	resp, err := s.executeOnPool(ctx, sql, rPool)
 	if err != nil {
 		// Fallback to writer
+		if balancer != nil {
+			balancer.MarkUnhealthy(readerAddr)
+		}
 		if s.met != nil {
 			s.met.ReaderFallback.Inc()
 		}

--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -73,6 +73,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		acquireSpan.SetStatus(codes.Error, err.Error())
 		acquireSpan.End()
 		slog.Warn("acquire reader failed for extended query, fallback to writer", "addr", readerAddr, "error", err)
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return fallbackToWriter()
 	}
 	acquireSpan.End()
@@ -99,6 +100,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		execSpan.End()
 		slog.Error("forward ext to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return fallbackToWriter()
 	}
 
@@ -112,6 +114,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 		rPool.Release(rConn)
 		execSpan.End()
 		if err != nil {
+			dbg.balancer.MarkUnhealthy(readerAddr)
 			return fmt.Errorf("relay reader extended response: %w", err)
 		}
 		// Cache the response keyed by the batch (first Parse query), skip if oversize
@@ -133,6 +136,7 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 			execSpan.SetStatus(codes.Error, err.Error())
 			execSpan.End()
 			rPool.Discard(rConn)
+			dbg.balancer.MarkUnhealthy(readerAddr)
 			return fmt.Errorf("relay reader extended response: %w", err)
 		}
 		if stopTimer != nil {
@@ -256,6 +260,7 @@ func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn,
 
 	rConn, err := rPool.Acquire(ctx)
 	if err != nil {
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return fallbackToWriter()
 	}
 
@@ -263,12 +268,14 @@ func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn,
 	if err := protocol.WriteMessage(rConn, protocol.MsgQuery, queryPayload); err != nil {
 		ct.clear()
 		rPool.Discard(rConn)
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return fallbackToWriter()
 	}
 
 	if err := s.relayUntilReady(clientConn, rConn); err != nil {
 		ct.clear()
 		rPool.Discard(rConn)
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return fmt.Errorf("relay reader synthesized response: %w", err)
 	}
 	ct.clear()

--- a/internal/proxy/query_read.go
+++ b/internal/proxy/query_read.go
@@ -86,6 +86,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		if cb, ok := dbg.ReaderCB(readerAddr); ok {
 			cb.RecordFailure()
 		}
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return s.fallbackToWriter(poolCtx, clientConn, msg, ct, dbg)
 	}
 	if s.metrics != nil {
@@ -116,6 +117,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 		}
 		slog.Error("forward to reader", "addr", readerAddr, "error", err)
 		rPool.Discard(rConn)
+		dbg.balancer.MarkUnhealthy(readerAddr)
 		return s.fallbackToWriter(poolCtx, clientConn, msg, ct, dbg)
 	}
 
@@ -134,6 +136,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 			if cb, ok := dbg.ReaderCB(readerAddr); ok {
 				cb.RecordFailure()
 			}
+			dbg.balancer.MarkUnhealthy(readerAddr)
 			return fmt.Errorf("relay reader response: %w", err)
 		}
 		rPool.Release(rConn)
@@ -160,6 +163,7 @@ func (s *Server) handleReadQueryTraced(traceCtx, poolCtx context.Context, client
 			if cb, ok := dbg.ReaderCB(readerAddr); ok {
 				cb.RecordFailure()
 			}
+			dbg.balancer.MarkUnhealthy(readerAddr)
 			return fmt.Errorf("relay reader response: %w", err)
 		}
 		if stopTimer != nil {


### PR DESCRIPTION
## 변경 사항

- **`internal/proxy/query_read.go`**: `handleReadQueryTraced()`의 4개 reader 에러 경로(pool acquire 실패, ForwardRaw 실패, relayAndCollect 실패, relayUntilReady 실패)에 `dbg.balancer.MarkUnhealthy(readerAddr)` 호출 추가
- **`internal/proxy/query_extended.go`**: `handleExtendedRead()`의 4개 에러 경로(acquire 실패, forwardExtBatch 실패, relayAndCollect 실패, relayUntilReady 실패) 및 `handleSynthesizedRead()`의 3개 에러 경로(acquire 실패, WriteMessage 실패, relayUntilReady 실패)에 `dbg.balancer.MarkUnhealthy(readerAddr)` 호출 추가
- **`internal/dataapi/handler.go`**: `executeRead()`에서 reader `executeOnPool` 실패 시 `balancer.MarkUnhealthy(readerAddr)` 호출 추가

## 원인

`balancer.MarkUnhealthy()`가 정의되어 있지만 실제 운영 코드에서 호출되지 않아, reader 장애 시 해당 reader가 로테이션에서 제외되지 않음. 특히 `circuit_breaker.enabled=false`(기본값)인 경우, 죽은 reader로 계속 요청이 라우팅되는 문제 발생.

## 테스트

- [x] `go build ./...` 컴파일 확인
- [x] 기존 circuit breaker 로직과 병행 동작 (CB가 활성화된 경우 RecordFailure + MarkUnhealthy 모두 호출)
- [x] `StartHealthCheck` goroutine이 주기적으로 unhealthy backend를 복구하므로, 일시적 장애 후 자동 복원됨

closes #197