### PR TITLE
fix(config): telemetry.sample_ratio: 0 설정이 NeverSample로 동작하지 않음 (#199)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type TelemetryConfig struct {
 	Exporter    string  `yaml:"exporter"`      // "otlp" or "stdout"
 	Endpoint    string  `yaml:"endpoint"`       // OTLP gRPC endpoint
 	ServiceName string  `yaml:"service_name"`
-	SampleRatio float64 `yaml:"sample_ratio"`   // 0.0 ~ 1.0
+	SampleRatio *float64 `yaml:"sample_ratio"`  // 0.0 ~ 1.0
 }
 
 type DataAPIConfig struct {
@@ -361,8 +361,9 @@ func (c *Config) applyDefaults() {
 	if c.Telemetry.ServiceName == "" {
 		c.Telemetry.ServiceName = "pgmux"
 	}
-	if c.Telemetry.SampleRatio == 0 {
-		c.Telemetry.SampleRatio = 1.0
+	if c.Telemetry.SampleRatio == nil {
+		defaultRatio := 1.0
+		c.Telemetry.SampleRatio = &defaultRatio
 	}
 	if c.Mirror.Mode == "" {
 		c.Mirror.Mode = "read_only"

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -61,13 +61,14 @@ func Init(cfg config.TelemetryConfig) (shutdown func(context.Context) error, err
 		return nil, fmt.Errorf("unknown telemetry exporter: %q", cfg.Exporter)
 	}
 
+	ratio := *cfg.SampleRatio
 	var sampler sdktrace.Sampler
-	if cfg.SampleRatio >= 1.0 {
+	if ratio >= 1.0 {
 		sampler = sdktrace.AlwaysSample()
-	} else if cfg.SampleRatio <= 0 {
+	} else if ratio <= 0 {
 		sampler = sdktrace.NeverSample()
 	} else {
-		sampler = sdktrace.TraceIDRatioBased(cfg.SampleRatio)
+		sampler = sdktrace.TraceIDRatioBased(ratio)
 	}
 
 	tp := sdktrace.NewTracerProvider(
@@ -86,7 +87,7 @@ func Init(cfg config.TelemetryConfig) (shutdown func(context.Context) error, err
 		"exporter", cfg.Exporter,
 		"endpoint", cfg.Endpoint,
 		"service", cfg.ServiceName,
-		"sample_ratio", cfg.SampleRatio)
+		"sample_ratio", *cfg.SampleRatio)
 
 	return tp.Shutdown, nil
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -19,12 +19,14 @@ func TestInit_Disabled(t *testing.T) {
 	}
 }
 
+func ptrFloat64(v float64) *float64 { return &v }
+
 func TestInit_Stdout(t *testing.T) {
 	shutdown, err := Init(config.TelemetryConfig{
 		Enabled:     true,
 		Exporter:    "stdout",
 		ServiceName: "pgmux-test",
-		SampleRatio: 1.0,
+		SampleRatio: ptrFloat64(1.0),
 	})
 	if err != nil {
 		t.Fatalf("Init stdout: %v", err)
@@ -60,7 +62,7 @@ func TestInit_SampleRatioZero(t *testing.T) {
 		Enabled:     true,
 		Exporter:    "stdout",
 		ServiceName: "pgmux-test",
-		SampleRatio: 0,
+		SampleRatio: ptrFloat64(0),
 	})
 	if err != nil {
 		t.Fatalf("Init with zero sample ratio: %v", err)
@@ -73,7 +75,7 @@ func TestInit_SampleRatioFractional(t *testing.T) {
 		Enabled:     true,
 		Exporter:    "stdout",
 		ServiceName: "pgmux-test",
-		SampleRatio: 0.5,
+		SampleRatio: ptrFloat64(0.5),
 	})
 	if err != nil {
 		t.Fatalf("Init with fractional sample ratio: %v", err)


### PR DESCRIPTION
## 변경 사항

- `TelemetryConfig.SampleRatio`의 타입을 `float64`에서 `*float64`로 변경하여 nil(미설정)과 0(명시적 설정)을 구분
- `applyDefaults()`에서 `== 0` 비교를 `== nil` 비교로 변경하여, `sample_ratio: 0` 설정 시 기본값 1.0으로 덮어쓰지 않도록 수정
- `telemetry.go`에서 포인터 역참조하여 sampler 로직 및 로그 출력 업데이트
- 테스트 파일의 `SampleRatio` 값을 `*float64` 포인터로 업데이트

## 원인

YAML은 `sample_ratio: 0`을 `float64(0)`으로 unmarshal하지만, `applyDefaults()`에서 `== 0`을 "미설정"으로 간주하여 1.0(AlwaysSample)으로 덮어씀. 이로 인해 `telemetry.go:67`의 NeverSample 분기가 YAML 설정으로는 도달 불가능했음.

## 테스트

- `go build ./...` 컴파일 확인
- `go test ./internal/telemetry/ -v` 전체 통과 (TestInit_SampleRatioZero 포함)

closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)