### PR TITLE
fix(admin): IP allowlist X-Forwarded-For spoofing 취약점 (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ admin:
     ip_allowlist:                  # 선택사항 — 허용 IP/CIDR (비어있으면 모든 IP 허용)
       - "10.0.0.0/8"
       - "172.16.0.0/12"
+    trusted_proxies:               # 선택사항 — X-Forwarded-For를 신뢰할 리버스 프록시 IP/CIDR (비어있으면 XFF 무시)
+      - "10.0.0.1"
+      - "172.16.0.0/12"
 
 data_api:
   enabled: false

--- a/README_en.md
+++ b/README_en.md
@@ -240,6 +240,9 @@ admin:
     ip_allowlist:                  # Optional -- allowed IP/CIDRs (empty = allow all)
       - "10.0.0.0/8"
       - "172.16.0.0/12"
+    trusted_proxies:               # Optional -- reverse proxy IPs/CIDRs that may set X-Forwarded-For (empty = never trust XFF)
+      - "10.0.0.1"
+      - "172.16.0.0/12"
 
 data_api:
   enabled: false

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -577,6 +577,8 @@ admin:
         role: "admin"
     ip_allowlist:
       - "10.0.0.0/8"
+    trusted_proxies:
+      - "10.0.0.1"
 ```
 
 #### Stats 응답 예시

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -90,7 +90,7 @@ func (s *Server) withAuth(next http.HandlerFunc, requireAdmin bool) http.Handler
 
 		// IP allowlist check
 		if len(authCfg.IPAllowlist) > 0 {
-			clientIP := extractClientIP(r)
+			clientIP := extractClientIP(r, authCfg.TrustedProxies)
 			if !isIPAllowed(clientIP, authCfg.IPAllowlist) {
 				writeJSONError(w, http.StatusForbidden, "ip not allowed")
 				return
@@ -135,18 +135,44 @@ func extractBearerToken(r *http.Request) string {
 	return ""
 }
 
-func extractClientIP(r *http.Request) string {
-	// Check X-Forwarded-For first (first IP is the original client)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.SplitN(xff, ",", 2)
-		return strings.TrimSpace(parts[0])
+func extractClientIP(r *http.Request, trustedProxies []string) string {
+	// Extract RemoteAddr (host part)
+	remoteIP := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		remoteIP = host
 	}
-	// Fall back to RemoteAddr (host:port)
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
+
+	// Only trust X-Forwarded-For if RemoteAddr is in trustedProxies.
+	// If trustedProxies is empty, NEVER trust XFF (secure default).
+	if len(trustedProxies) > 0 && isTrustedProxy(remoteIP, trustedProxies) {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.SplitN(xff, ",", 2)
+			return strings.TrimSpace(parts[0])
+		}
 	}
-	return host
+
+	return remoteIP
+}
+
+// isTrustedProxy checks whether the given IP is in the trusted proxy list.
+func isTrustedProxy(ip string, trustedProxies []string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, entry := range trustedProxies {
+		_, cidr, err := net.ParseCIDR(entry)
+		if err == nil {
+			if cidr.Contains(parsed) {
+				return true
+			}
+			continue
+		}
+		if net.ParseIP(entry) != nil && entry == ip {
+			return true
+		}
+	}
+	return false
 }
 
 func isIPAllowed(clientIP string, allowlist []string) bool {
@@ -418,9 +444,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 			Enabled bool `json:"enabled"`
 			Listen  string `json:"listen"`
 			Auth    struct {
-				Enabled     bool              `json:"enabled"`
-				APIKeys     []safeAdminAPIKey `json:"api_keys,omitempty"`
-				IPAllowlist []string          `json:"ip_allowlist,omitempty"`
+				Enabled        bool              `json:"enabled"`
+				APIKeys        []safeAdminAPIKey `json:"api_keys,omitempty"`
+				IPAllowlist    []string          `json:"ip_allowlist,omitempty"`
+				TrustedProxies []string          `json:"trusted_proxies,omitempty"`
 			} `json:"auth"`
 		} `json:"admin"`
 		Backend struct {
@@ -449,6 +476,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	safe.Admin.Listen = cfg.Admin.Listen
 	safe.Admin.Auth.Enabled = cfg.Admin.Auth.Enabled
 	safe.Admin.Auth.IPAllowlist = cfg.Admin.Auth.IPAllowlist
+	safe.Admin.Auth.TrustedProxies = cfg.Admin.Auth.TrustedProxies
 	for _, k := range cfg.Admin.Auth.APIKeys {
 		safe.Admin.Auth.APIKeys = append(safe.Admin.Auth.APIKeys, safeAdminAPIKey{
 			Key:  "********",

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -921,14 +921,15 @@ func TestAuth_IPAllowlist_Denied(t *testing.T) {
 	}
 }
 
-func TestAuth_IPAllowlist_XForwardedFor(t *testing.T) {
+func TestAuth_IPAllowlist_XForwardedFor_WithTrustedProxy(t *testing.T) {
 	cfg := testConfig()
 	cfg.Admin.Auth = config.AdminAuthConfig{
 		Enabled: true,
 		APIKeys: []config.AdminAPIKey{
 			{Key: "key", Role: "admin"},
 		},
-		IPAllowlist: []string{"192.168.1.100"},
+		IPAllowlist:    []string{"192.168.1.100"},
+		TrustedProxies: []string{"192.0.2.1"},
 	}
 
 	srv := New(
@@ -941,29 +942,102 @@ func TestAuth_IPAllowlist_XForwardedFor(t *testing.T) {
 		nil, nil, nil, nil,
 	)
 
-	// Use httptest.NewRecorder to control RemoteAddr
 	handler := srv.HTTPServer().Handler
 
-	// X-Forwarded-For with allowed IP
+	// X-Forwarded-For with allowed IP, sent from trusted proxy
 	req := httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
+	req.RemoteAddr = "192.0.2.1:12345"
 	req.Header.Set("Authorization", "Bearer key")
 	req.Header.Set("X-Forwarded-For", "192.168.1.100, 10.0.0.1")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("XFF allowed: status = %d, want 200", w.Code)
+		t.Errorf("XFF from trusted proxy allowed: status = %d, want 200", w.Code)
 	}
 
-	// X-Forwarded-For with denied IP
+	// X-Forwarded-For with denied IP, sent from trusted proxy
 	req2 := httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
+	req2.RemoteAddr = "192.0.2.1:12345"
 	req2.Header.Set("Authorization", "Bearer key")
 	req2.Header.Set("X-Forwarded-For", "10.0.0.1")
 	w2 := httptest.NewRecorder()
 	handler.ServeHTTP(w2, req2)
 
 	if w2.Code != http.StatusForbidden {
-		t.Errorf("XFF denied: status = %d, want 403", w2.Code)
+		t.Errorf("XFF from trusted proxy denied: status = %d, want 403", w2.Code)
+	}
+}
+
+func TestAuth_IPAllowlist_XForwardedFor_Spoofing(t *testing.T) {
+	cfg := testConfig()
+	cfg.Admin.Auth = config.AdminAuthConfig{
+		Enabled: true,
+		APIKeys: []config.AdminAPIKey{
+			{Key: "key", Role: "admin"},
+		},
+		IPAllowlist: []string{"192.168.1.100"},
+		// No trusted proxies — XFF should be ignored
+	}
+
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return nil },
+		func() *cache.Invalidator { return nil },
+		func() map[string]*proxy.DatabaseGroup { return nil },
+		"testdb",
+		func() *audit.Logger { return nil },
+		nil, nil, nil, nil,
+	)
+
+	handler := srv.HTTPServer().Handler
+
+	// Attacker sets X-Forwarded-For to bypass IP allowlist — should be denied
+	req := httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
+	req.RemoteAddr = "1.2.3.4:9999"
+	req.Header.Set("Authorization", "Bearer key")
+	req.Header.Set("X-Forwarded-For", "192.168.1.100")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("XFF spoofing without trusted proxy: status = %d, want 403", w.Code)
+	}
+}
+
+func TestAuth_IPAllowlist_XForwardedFor_UntrustedProxy(t *testing.T) {
+	cfg := testConfig()
+	cfg.Admin.Auth = config.AdminAuthConfig{
+		Enabled: true,
+		APIKeys: []config.AdminAPIKey{
+			{Key: "key", Role: "admin"},
+		},
+		IPAllowlist:    []string{"192.168.1.100"},
+		TrustedProxies: []string{"10.0.0.1"},
+	}
+
+	srv := New(
+		func() *config.Config { return cfg },
+		func() *cache.Cache { return nil },
+		func() *cache.Invalidator { return nil },
+		func() map[string]*proxy.DatabaseGroup { return nil },
+		"testdb",
+		func() *audit.Logger { return nil },
+		nil, nil, nil, nil,
+	)
+
+	handler := srv.HTTPServer().Handler
+
+	// XFF sent from untrusted proxy — XFF should be ignored, use RemoteAddr
+	req := httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
+	req.RemoteAddr = "172.16.0.1:9999"
+	req.Header.Set("Authorization", "Bearer key")
+	req.Header.Set("X-Forwarded-For", "192.168.1.100")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("XFF from untrusted proxy: status = %d, want 403", w.Code)
 	}
 }
 
@@ -1057,14 +1131,19 @@ func TestAuth_ErrorResponseFormat(t *testing.T) {
 
 func TestExtractClientIP(t *testing.T) {
 	tests := []struct {
-		name       string
-		remoteAddr string
-		xff        string
-		want       string
+		name           string
+		remoteAddr     string
+		xff            string
+		trustedProxies []string
+		want           string
 	}{
-		{"remote addr with port", "192.168.1.1:12345", "", "192.168.1.1"},
-		{"xff single", "10.0.0.1:1234", "192.168.1.100", "192.168.1.100"},
-		{"xff chain", "10.0.0.1:1234", "192.168.1.100, 10.0.0.2, 10.0.0.3", "192.168.1.100"},
+		{"remote addr with port", "192.168.1.1:12345", "", nil, "192.168.1.1"},
+		{"xff ignored without trusted proxies", "10.0.0.1:1234", "192.168.1.100", nil, "10.0.0.1"},
+		{"xff ignored with empty trusted proxies", "10.0.0.1:1234", "192.168.1.100", []string{}, "10.0.0.1"},
+		{"xff trusted proxy single", "10.0.0.1:1234", "192.168.1.100", []string{"10.0.0.1"}, "192.168.1.100"},
+		{"xff trusted proxy chain", "10.0.0.1:1234", "192.168.1.100, 10.0.0.2", []string{"10.0.0.1"}, "192.168.1.100"},
+		{"xff trusted proxy cidr", "10.0.0.1:1234", "192.168.1.100", []string{"10.0.0.0/8"}, "192.168.1.100"},
+		{"xff untrusted proxy", "172.16.0.1:1234", "192.168.1.100", []string{"10.0.0.1"}, "172.16.0.1"},
 	}
 
 	for _, tt := range tests {
@@ -1074,7 +1153,7 @@ func TestExtractClientIP(t *testing.T) {
 			if tt.xff != "" {
 				r.Header.Set("X-Forwarded-For", tt.xff)
 			}
-			got := extractClientIP(r)
+			got := extractClientIP(r, tt.trustedProxies)
 			if got != tt.want {
 				t.Errorf("extractClientIP() = %q, want %q", got, tt.want)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,9 +92,10 @@ type AdminConfig struct {
 }
 
 type AdminAuthConfig struct {
-	Enabled     bool          `yaml:"enabled"`
-	APIKeys     []AdminAPIKey `yaml:"api_keys"`
-	IPAllowlist []string      `yaml:"ip_allowlist"`
+	Enabled        bool          `yaml:"enabled"`
+	APIKeys        []AdminAPIKey `yaml:"api_keys"`
+	IPAllowlist    []string      `yaml:"ip_allowlist"`
+	TrustedProxies []string      `yaml:"trusted_proxies"`
 }
 
 type AdminAPIKey struct {
@@ -495,6 +496,14 @@ func (c *Config) validate() error {
 				// Try as single IP
 				if ip := net.ParseIP(cidr); ip == nil {
 					return fmt.Errorf("admin.auth.ip_allowlist[%d] %q is not a valid IP or CIDR", i, cidr)
+				}
+			}
+		}
+		for i, cidr := range c.Admin.Auth.TrustedProxies {
+			if _, _, err := net.ParseCIDR(cidr); err != nil {
+				// Try as single IP
+				if ip := net.ParseIP(cidr); ip == nil {
+					return fmt.Errorf("admin.auth.trusted_proxies[%d] %q is not a valid IP or CIDR", i, cidr)
 				}
 			}
 		}


### PR DESCRIPTION
## 변경 사항

- `extractClientIP()`가 `X-Forwarded-For` 헤더를 무조건 신뢰하여, 공격자가 `X-Forwarded-For: <허용된 IP>`를 설정해 IP allowlist를 우회할 수 있는 보안 취약점 수정
- `AdminAuthConfig`에 `trusted_proxies` 필드 추가 — XFF를 신뢰할 리버스 프록시 IP/CIDR 목록
- `extractClientIP(r, trustedProxies)`로 시그니처 변경: RemoteAddr가 trusted_proxies에 포함된 경우에만 XFF를 신뢰
- `trusted_proxies`가 비어있으면 XFF를 절대 신뢰하지 않음 (secure default)
- config 유효성 검증에 `trusted_proxies` IP/CIDR 형식 검증 추가
- `/admin/config` 응답에 `trusted_proxies` 필드 노출
- README.md, README_en.md, docs/implementation.md 설정 예시 업데이트

## 테스트

- [x] `TestExtractClientIP` — trusted proxy 있을 때/없을 때 XFF 동작 검증 (7 케이스)
- [x] `TestAuth_IPAllowlist_XForwardedFor_WithTrustedProxy` — trusted proxy에서 XFF 정상 동작
- [x] `TestAuth_IPAllowlist_XForwardedFor_Spoofing` — trusted proxy 없이 XFF spoofing 차단
- [x] `TestAuth_IPAllowlist_XForwardedFor_UntrustedProxy` — untrusted proxy에서 XFF 무시
- [x] 기존 admin 테스트 전체 통과 (35/35)
- [x] config 테스트 전체 통과

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)