### PR TITLE
fix(pool): Close()가 outstanding borrow를 무시하고 numOpen=0으로 덮어쓰는 race (#208)

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -193,7 +193,9 @@ func (p *Pool) Release(conn *Conn) {
 
 	if p.closed {
 		conn.Close()
-		p.numOpen--
+		if p.numOpen > 0 {
+			p.numOpen--
+		}
 		return
 	}
 
@@ -216,11 +218,12 @@ func (p *Pool) Close() {
 	}
 	p.closed = true
 	close(p.done) // stop health check goroutine
+	idleCount := len(p.idle)
 	for _, conn := range p.idle {
 		conn.Close()
 	}
 	p.idle = nil
-	p.numOpen = 0
+	p.numOpen -= idleCount // only subtract idle conns, preserve outstanding borrow count
 }
 
 // Stats returns current pool statistics.
@@ -235,7 +238,9 @@ func (p *Pool) Stats() (numOpen, numIdle int) {
 func (p *Pool) Discard(conn *Conn) {
 	conn.Close()
 	p.mu.Lock()
-	p.numOpen--
+	if p.numOpen > 0 {
+		p.numOpen--
+	}
 	p.mu.Unlock()
 
 	select {


### PR DESCRIPTION
## 변경 사항

- **Close()**: `numOpen = 0` 대신 `numOpen -= idleCount`로 변경하여 현재 borrow 중인 커넥션 수를 보존
- **Release() closed 경로**: `numOpen--` 전에 `numOpen > 0` 가드 추가하여 음수 방지
- **Discard()**: 동일하게 `numOpen > 0` 가드 추가

### Race 시나리오 (수정 전)
1. Goroutine A: `Acquire()` → `numOpen++` (5→6), unlock, `newConn()` 시작
2. Goroutine B: `Close()` → idle 5개 닫고 `numOpen = 0`으로 덮어씀
3. Goroutine A: `newConn()` 완료, 커넥션 반환
4. Caller: `Release(conn)` → `numOpen--` → **numOpen = -1** (버그)

### 수정 후
- `Close()`는 `numOpen -= 5` (idle 수만큼만 차감) → `numOpen = 1` (borrow 중인 1개 보존)
- `Release(conn)` → `numOpen--` → `numOpen = 0` (정상)

## 테스트

- [x] `go build ./...` 성공

Closes #208