### PR TITLE
fix(cache): extended query 캐시 키가 Bind 파라미터를 무시하여 잘못된 결과 반환 (#207)

### DIFF
--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -23,7 +23,10 @@ import (
 // handleExtendedRead sends buffered Extended Query messages to a reader, falling back to writer.
 func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, buf []*protocol.Message, syncMsg *protocol.Message, readerAddr string, ct *cancelTarget, dbg *DatabaseGroup, queryTimeout ...time.Duration) error {
 	// Cache lookup — mirror the simple-query read path (query_read.go)
-	if s.queryCache != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
+	// Skip cache entirely for parameterized queries to avoid returning
+	// wrong results when bind parameters differ (issue #207).
+	cacheable := !hasParameterPlaceholders(buf)
+	if cacheable && s.queryCache != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
 		_, query := protocol.ParseParseMessage(buf[0].Payload)
 		key := cache.WithNamespace(s.cacheKey(query, dbg.name), cache.NSExtended)
 		if cached := s.queryCache.Get(key); cached != nil {
@@ -134,8 +137,9 @@ func (s *Server) handleExtendedRead(ctx context.Context, clientConn net.Conn, bu
 			dbg.balancer.MarkUnhealthy(readerAddr)
 			return fmt.Errorf("relay reader extended response: %w", err)
 		}
-		// Cache the response keyed by the batch (first Parse query), skip if oversize
-		if collected != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
+		// Cache the response keyed by the batch (first Parse query), skip if oversize.
+		// Skip parameterized queries — bind params are not part of the key (#207).
+		if cacheable && collected != nil && len(buf) > 0 && buf[0].Type == protocol.MsgParse {
 			_, query := protocol.ParseParseMessage(buf[0].Payload)
 			key := cache.WithNamespace(s.cacheKey(query, dbg.name), cache.NSExtended)
 			tables := s.extractReadQueryTables(query)
@@ -298,6 +302,23 @@ func (s *Server) handleSynthesizedRead(ctx context.Context, clientConn net.Conn,
 	ct.clear()
 	rPool.Release(rConn)
 	return nil
+}
+
+// hasParameterPlaceholders reports whether the Parse message in buf contains
+// $N parameter placeholders. Queries with placeholders must not be cached
+// because the cache key does not include bind parameter values (#207).
+func hasParameterPlaceholders(buf []*protocol.Message) bool {
+	for _, m := range buf {
+		if m.Type == protocol.MsgParse {
+			_, query := protocol.ParseParseMessage(m.Payload)
+			for i := 0; i < len(query)-1; i++ {
+				if query[i] == '$' && query[i+1] >= '1' && query[i+1] <= '9' {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // handleMultiplexDescribe handles Describe messages in multiplex mode.


### PR DESCRIPTION
## 변경 사항

- Extended Query Protocol에서 `$N` 파라미터 플레이스홀더가 포함된 prepared statement는 캐시를 완전히 건너뛰도록 수정
- `hasParameterPlaceholders()` 헬퍼 함수 추가: Parse 메시지의 SQL 텍스트에서 `$1`~`$9` 패턴을 감지
- 캐시 읽기(lookup)와 캐시 쓰기(store) 경로 모두에 가드 적용

### 근본 원인

`handleExtendedRead()`에서 캐시 키를 Parse 메시지의 SQL 텍스트만으로 생성하고 Bind 파라미터 값을 포함하지 않았음. 따라서 동일 SQL에 다른 파라미터(`$1=1` vs `$1=2`)로 호출하면 첫 번째 결과가 반환되는 데이터 정합성 버그 발생.

### 수정 방식

파라미터 플레이스홀더가 있는 쿼리는 캐시를 아예 사용하지 않음. 리터럴 값만 포함된 쿼리(예: `SELECT 1`, `SELECT * FROM config`)는 기존대로 캐시됨.

## 테스트

- [x] `go build ./...` 성공

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)