### PR TITLE
fix(proxy): writer circuit breaker가 hot-reload 대상에서 누락 (#209)

### DIFF
--- a/internal/proxy/dbgroup.go
+++ b/internal/proxy/dbgroup.go
@@ -205,13 +205,21 @@ func (g *DatabaseGroup) Reload(dbCfg config.DatabaseConfig, cbCfg config.Circuit
 	g.backendCfg = dbCfg.Backend
 
 	if cbCfg.Enabled {
-		newCBs := make(map[string]*resilience.CircuitBreaker)
 		brCfg := resilience.BreakerConfig{
 			ErrorThreshold: cbCfg.ErrorThreshold,
 			OpenDuration:   cbCfg.OpenDuration,
 			HalfOpenMax:    cbCfg.HalfOpenMax,
 			WindowSize:     cbCfg.WindowSize,
 		}
+
+		// Writer circuit breaker — create if nil (was previously disabled)
+		if g.writerCB == nil {
+			g.writerCB = resilience.NewCircuitBreaker(brCfg)
+			slog.Info("reload: writer circuit breaker enabled", "db", g.name)
+		}
+
+		// Reader circuit breakers — preserve existing, create for new addrs
+		newCBs := make(map[string]*resilience.CircuitBreaker)
 		for _, addr := range newReaderAddrs {
 			if cb, ok := g.readerCBs[addr]; ok {
 				newCBs[addr] = cb
@@ -220,6 +228,16 @@ func (g *DatabaseGroup) Reload(dbCfg config.DatabaseConfig, cbCfg config.Circuit
 			}
 		}
 		g.readerCBs = newCBs
+	} else {
+		// CB disabled — clear writer and reader circuit breakers
+		if g.writerCB != nil {
+			g.writerCB = nil
+			slog.Info("reload: writer circuit breaker disabled", "db", g.name)
+		}
+		if g.readerCBs != nil {
+			g.readerCBs = nil
+			slog.Info("reload: reader circuit breakers disabled", "db", g.name)
+		}
 	}
 }
 


### PR DESCRIPTION
## 변경 사항

- `Reload()`에서 `writerCB`가 업데이트되지 않던 버그 수정
  - CB가 비활성→활성으로 변경 시 `writerCB`가 nil로 남는 문제 해결
  - CB가 활성→비활성으로 변경 시 `writerCB`와 `readerCBs`가 정리되지 않던 문제 해결
- `else` 분기 추가: CB 비활성화 시 writer/reader CB 모두 nil 처리

## 테스트

- [x] `go build ./...` 성공
- [ ] CB 비활성 → 활성 reload 시 writerCB 생성 확인
- [ ] CB 활성 → 비활성 reload 시 writerCB/readerCBs nil 확인

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)