### PR TITLE
fix(proxy): boundWriter가 reload 후 new pool로 반환되는 cross-pool 오염 (#206)

### DIFF
--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -58,6 +58,30 @@ func (s *Server) releaseWriterFast(conn *pool.Conn, dbg *DatabaseGroup) {
 	dbg.writerPool.Release(conn)
 }
 
+// resetAndReleaseToPool sends DISCARD ALL and returns the connection to the specified pool.
+// Use this instead of resetAndReleaseWriter when the connection may outlive a config reload
+// (e.g., boundWriter in a transaction), to ensure Release goes to the pool that issued Acquire.
+func (s *Server) resetAndReleaseToPool(conn *pool.Conn, p *pool.Pool) {
+	if err := s.resetConn(conn); err != nil {
+		slog.Warn("reset writer conn failed, discarding", "error", err)
+		p.Discard(conn)
+		return
+	}
+	p.Release(conn)
+}
+
+// releaseToPool returns the connection to the specified pool without DISCARD ALL.
+// Use this instead of releaseWriterFast when the connection may outlive a config reload.
+func releaseToPool(conn *pool.Conn, p *pool.Pool) {
+	p.Release(conn)
+}
+
+// discardToPool discards the connection to the specified pool.
+// Use this instead of dbg.writerPool.Discard when the connection may outlive a config reload.
+func discardToPool(conn *pool.Conn, p *pool.Pool) {
+	p.Discard(conn)
+}
+
 // resetConn sends the configured reset query (e.g. DISCARD ALL) to clean up session state
 // before returning a connection to the pool.
 func (s *Server) resetConn(conn net.Conn) error {

--- a/internal/proxy/query.go
+++ b/internal/proxy/query.go
@@ -24,6 +24,10 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 	// boundWriter is non-nil when a transaction is in progress.
 	// The connection stays bound from BEGIN until COMMIT/ROLLBACK.
 	var boundWriter *pool.Conn
+	// boundWriterPool tracks the pool from which boundWriter was acquired.
+	// On config reload, dbg.writerPool may be replaced with a new pool.
+	// We must Release/Discard to the original pool to avoid cross-pool contamination.
+	var boundWriterPool *pool.Pool
 	// connDirty tracks if the current borrow cycle has seen session-modifying commands
 	// (SET, PREPARE, LISTEN, CREATE TEMP, etc.) that require DISCARD ALL on release.
 	var connDirty bool
@@ -31,9 +35,9 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 	defer func() {
 		if boundWriter != nil {
 			if connDirty {
-				s.resetAndReleaseWriter(boundWriter, dbg)
+				s.resetAndReleaseToPool(boundWriter, boundWriterPool)
 			} else {
-				s.releaseWriterFast(boundWriter, dbg)
+				releaseToPool(boundWriter, boundWriterPool)
 			}
 		}
 	}()
@@ -200,6 +204,10 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 			queryTimeout := s.resolveQueryTimeout(query, queryCfg)
 
 			if route == router.RouteWriter {
+				// Capture the current writerPool reference before acquire.
+				// If acquired==true, this is the pool the conn came from.
+				// If acquired==false (reusing boundWriter), acquiredPool is unused.
+				acquiredPool := dbg.writerPool
 				wConn, acquired, err := s.acquireWriterConn(ctx, boundWriter, dbg)
 				if err != nil {
 					if tracingEnabled {
@@ -229,23 +237,26 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				case !wasInTx && nowInTx:
 					// BEGIN — bind writer for transaction duration
 					boundWriter = wConn
+					boundWriterPool = acquiredPool
 				case wasInTx && !nowInTx:
-					// COMMIT/ROLLBACK — unbind and release
+					// COMMIT/ROLLBACK — unbind and release to the pool that issued Acquire
+					bwp := boundWriterPool
 					boundWriter = nil
+					boundWriterPool = nil
 					if connDirty {
-						s.resetAndReleaseWriter(wConn, dbg)
+						s.resetAndReleaseToPool(wConn, bwp)
 					} else {
-						s.releaseWriterFast(wConn, dbg)
+						releaseToPool(wConn, bwp)
 					}
 					connDirty = false
 				case acquired:
 					// Single statement outside transaction — release immediately
 					// Skip DISCARD ALL unless session state was modified
 					if connDirty || isSessionModifying(query) {
-						s.resetAndReleaseWriter(wConn, dbg)
+						s.resetAndReleaseToPool(wConn, acquiredPool)
 						connDirty = false
 					} else {
-						s.releaseWriterFast(wConn, dbg)
+						releaseToPool(wConn, acquiredPool)
 					}
 				}
 				// If !acquired && still in transaction → keep using boundWriter
@@ -428,7 +439,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				slog.Debug("synthesized query", "sql", synthesized, "route", target)
 				extSpan.SetAttributes(attribute.String("db.statement", truncateStr(synthesized, 100)))
 
-				if err := s.executeSynthesizedQuery(extCtx, clientConn, synthesized, extRoute, session, &boundWriter, extTxStart, extTxEnd, ct, dbg); err != nil {
+				if err := s.executeSynthesizedQuery(extCtx, clientConn, synthesized, extRoute, session, &boundWriter, &boundWriterPool, extTxStart, extTxEnd, ct, dbg); err != nil {
 					extSpan.SetStatus(codes.Error, err.Error())
 					extSpan.End()
 					slog.Error("execute synthesized query", "error", err)
@@ -449,6 +460,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				}
 			} else {
 				// Writer path (proxy mode) — acquire from pool or use bound connection
+				acquiredPool := dbg.writerPool
 				_, acquireSpan := telemetry.Tracer().Start(extCtx, "pgmux.pool.acquire",
 					trace.WithAttributes(attribute.String("pgmux.route", "writer")),
 				)
@@ -484,10 +496,11 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 					extSpan.End()
 					slog.Error("forward ext batch to writer", "error", writeErr)
 					if acquired {
-						dbg.writerPool.Discard(wConn)
+						discardToPool(wConn, acquiredPool)
 					} else if boundWriter != nil {
-						dbg.writerPool.Discard(boundWriter)
+						discardToPool(boundWriter, boundWriterPool)
 						boundWriter = nil
+						boundWriterPool = nil
 					}
 					return
 				}
@@ -503,10 +516,11 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 					extSpan.End()
 					slog.Error("relay writer response (sync)", "error", err)
 					if acquired {
-						dbg.writerPool.Discard(wConn)
+						discardToPool(wConn, acquiredPool)
 					} else if boundWriter != nil {
-						dbg.writerPool.Discard(boundWriter)
+						discardToPool(boundWriter, boundWriterPool)
 						boundWriter = nil
+						boundWriterPool = nil
 					}
 					return
 				}
@@ -529,22 +543,25 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				case extTxStart && !extTxEnd:
 					// BEGIN — bind writer
 					boundWriter = wConn
+					boundWriterPool = acquiredPool
 				case extTxEnd:
-					// COMMIT/ROLLBACK — unbind and release
+					// COMMIT/ROLLBACK — unbind and release to origin pool
+					bwp := boundWriterPool
 					boundWriter = nil
+					boundWriterPool = nil
 					if connDirty {
-						s.resetAndReleaseWriter(wConn, dbg)
+						s.resetAndReleaseToPool(wConn, bwp)
 					} else {
-						s.releaseWriterFast(wConn, dbg)
+						releaseToPool(wConn, bwp)
 					}
 					connDirty = false
 				case acquired:
 					// Single batch outside transaction — release
 					if connDirty {
-						s.resetAndReleaseWriter(wConn, dbg)
+						s.resetAndReleaseToPool(wConn, acquiredPool)
 						connDirty = false
 					} else {
-						s.releaseWriterFast(wConn, dbg)
+						releaseToPool(wConn, acquiredPool)
 					}
 				}
 			}

--- a/internal/proxy/query_extended.go
+++ b/internal/proxy/query_extended.go
@@ -181,7 +181,7 @@ func (s *Server) forwardExtBatch(backendConn net.Conn, buf []*protocol.Message, 
 }
 
 // executeSynthesizedQuery executes a synthesized Simple Query on the appropriate backend.
-func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Conn, query string, route router.Route, session *router.Session, boundWriter **pool.Conn, extTxStart, extTxEnd bool, ct *cancelTarget, dbg *DatabaseGroup) error {
+func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Conn, query string, route router.Route, session *router.Session, boundWriter **pool.Conn, boundWriterPool **pool.Pool, extTxStart, extTxEnd bool, ct *cancelTarget, dbg *DatabaseGroup) error {
 	// Build Simple Query message
 	queryPayload := append([]byte(query), 0)
 
@@ -191,7 +191,8 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 		return s.handleSynthesizedRead(ctx, clientConn, queryPayload, readerAddr, ct, dbg)
 	}
 
-	// Writer path
+	// Writer path — capture pool reference before acquire
+	acquiredPool := dbg.writerPool
 	wConn, acquired, err := s.acquireWriterConn(ctx, *boundWriter, dbg)
 	if err != nil {
 		s.sendError(clientConn, "cannot acquire backend connection")
@@ -202,7 +203,7 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 	if err := protocol.WriteMessage(wConn, protocol.MsgQuery, queryPayload); err != nil {
 		ct.clear()
 		if acquired {
-			dbg.writerPool.Discard(wConn)
+			discardToPool(wConn, acquiredPool)
 		}
 		return fmt.Errorf("send synthesized query: %w", err)
 	}
@@ -210,10 +211,11 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 	if err := s.relayUntilReady(clientConn, wConn); err != nil {
 		ct.clear()
 		if acquired {
-			dbg.writerPool.Discard(wConn)
+			discardToPool(wConn, acquiredPool)
 		} else if *boundWriter != nil {
-			dbg.writerPool.Discard(*boundWriter)
+			discardToPool(*boundWriter, *boundWriterPool)
 			*boundWriter = nil
+			*boundWriterPool = nil
 		}
 		return fmt.Errorf("relay synthesized response: %w", err)
 	}
@@ -230,11 +232,14 @@ func (s *Server) executeSynthesizedQuery(ctx context.Context, clientConn net.Con
 	switch {
 	case extTxStart && !extTxEnd:
 		*boundWriter = wConn
+		*boundWriterPool = acquiredPool
 	case extTxEnd:
+		bwp := *boundWriterPool
 		*boundWriter = nil
-		s.resetAndReleaseWriter(wConn, dbg)
+		*boundWriterPool = nil
+		s.resetAndReleaseToPool(wConn, bwp)
 	case acquired:
-		s.resetAndReleaseWriter(wConn, dbg)
+		s.resetAndReleaseToPool(wConn, acquiredPool)
 	}
 	return nil
 }


### PR DESCRIPTION
## 변경 사항

- `boundWriterPool *pool.Pool` 변수를 추가하여, `boundWriter`가 Acquire된 원본 pool 참조를 추적
- `resetAndReleaseToPool`, `releaseToPool`, `discardToPool` 헬퍼를 `backend.go`에 추가하여 명시적 pool 참조로 Release/Discard 수행
- Simple Query / Extended Query / Synthesized Query의 모든 boundWriter release/discard 경로에서 `dbg.writerPool` 대신 캡처된 pool 참조 사용
- `executeSynthesizedQuery` 시그니처에 `boundWriterPool **pool.Pool` 파라미터 추가

## 원인

`Reload()`이 `dbg.writerPool`을 새 pool로 교체하면, 트랜잭션 중 보유하고 있던 `boundWriter`가 원래 pool이 아닌 새 pool로 반환됨:
1. 새 pool에 old backend socket이 혼입 (writer 주소 변경 시 잘못된 서버)
2. 새 pool의 `numOpen` 불일치 (해당 conn은 새 pool에서 Acquire된 적이 없음)

## 수정 원칙

**모든 Release/Discard는 해당 connection이 Acquire된 동일한 pool로 반환되어야 한다.**

## 테스트

- [x] `go build ./...` 컴파일 확인
- [ ] 기존 e2e/integration 테스트 통과 확인 (CI)

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)