### PR TITLE
fix: read-only 모드가 prepared statement 재사용으로 우회됨

### DIFF
--- a/internal/proxy/query.go
+++ b/internal/proxy/query.go
@@ -494,6 +494,9 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				if route == router.RouteWriter {
 					extRoute = router.RouteWriter
 				}
+				if session.StatementIsWrite(detail.StatementName) {
+					extIsWrite = true
+				}
 				muxBindDetail = detail
 				// Send BindComplete to client
 				if err := protocol.WriteMessage(clientConn, '2', nil); err != nil {
@@ -505,6 +508,9 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 				route := session.StatementRoute(stmtName)
 				if route == router.RouteWriter {
 					extRoute = router.RouteWriter
+				}
+				if session.StatementIsWrite(stmtName) {
+					extIsWrite = true
 				}
 				extBuf = append(extBuf, protocol.CopyMessage(msg))
 			}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -25,6 +25,9 @@ type Session struct {
 	// Prepared statement routing: statement name → route
 	stmtRoutes map[string]Route
 
+	// Prepared statement write tracking: statement name → is write query
+	stmtWrite map[string]bool
+
 	// Session pinning: when true, all queries are routed to writer
 	// and the backend connection is held for the session lifetime.
 	pinned       bool
@@ -37,6 +40,7 @@ func NewSession(readAfterWriteDelay time.Duration, causalConsistency bool, astPa
 		causalConsistency:   causalConsistency,
 		astParser:           astParser,
 		stmtRoutes:          make(map[string]Route),
+		stmtWrite:           make(map[string]bool),
 	}
 }
 
@@ -385,6 +389,16 @@ func (s *Session) RegisterStatement(name, query string) Route {
 
 	route := s.routeLocked(query)
 	s.stmtRoutes[name] = route
+
+	// Track write classification for read-only mode enforcement
+	var qtype QueryType
+	if s.astParser {
+		qtype = ClassifyAST(query)
+	} else {
+		qtype = Classify(query)
+	}
+	s.stmtWrite[name] = (qtype == QueryWrite)
+
 	return route
 }
 
@@ -398,6 +412,18 @@ func (s *Session) StatementRoute(name string) Route {
 		return route
 	}
 	return RouteWriter
+}
+
+// StatementIsWrite returns whether a previously registered prepared statement
+// is a write query. Returns true for unknown statements (safe default).
+func (s *Session) StatementIsWrite(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if isWrite, ok := s.stmtWrite[name]; ok {
+		return isWrite
+	}
+	return true // safe default: treat unknown as write
 }
 
 // SetLastWriteLSN records the WAL LSN after a write query.
@@ -445,6 +471,7 @@ func (s *Session) CloseStatement(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.stmtRoutes, name)
+	delete(s.stmtWrite, name)
 }
 
 // routeLocked determines the route without locking (caller must hold mu).


### PR DESCRIPTION
## 변경 사항

- `Session`에 `stmtWrite map[string]bool` 추가하여 statement별 write 분류 추적
- `RegisterStatement()`에서 write 분류 저장, `StatementIsWrite()` 메서드 추가
- `MsgBind` 핸들러(multiplex/proxy 양쪽)에서 statement write 여부 확인해 `extIsWrite` 설정
- Parse 없이 Bind/Execute/Sync만 보내는 배치에서도 read-only 체크가 정상 동작

## 테스트

- [x] `go build ./...` 성공
- [ ] read-only 모드에서 prepared statement 재사용 차단 확인
- [ ] 기존 Extended Query 동작 회귀 없음

closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)