### PR TITLE
fix: side-effectful SELECT가 read로 분류됨

### DIFF
--- a/internal/router/parser.go
+++ b/internal/router/parser.go
@@ -57,6 +57,10 @@ func Classify(query string) QueryType {
 		if keyword == "WITH" && containsWriteKeyword(stmt) {
 			return QueryWrite
 		}
+		// Side-effectful SELECT: FOR UPDATE/SHARE, nextval(), set_config(), etc.
+		if keyword == "SELECT" && isSideEffectfulSelect(stmt) {
+			return QueryWrite
+		}
 	}
 	return QueryRead
 }
@@ -102,6 +106,15 @@ func classifyFast(query string) (QueryType, bool) {
 	}
 	if kw == "WITH" {
 		return 0, false // CTE needs full parser
+	}
+	if kw == "SELECT" {
+		// Check for side-effectful patterns that need full analysis
+		upper := strings.ToUpper(query)
+		if strings.Contains(upper, "FOR UPDATE") || strings.Contains(upper, "FOR SHARE") ||
+			strings.Contains(upper, "FOR NO KEY UPDATE") || strings.Contains(upper, "FOR KEY SHARE") ||
+			hasSideEffectFunc(upper) {
+			return 0, false // need full parser
+		}
 	}
 	return QueryRead, true
 }
@@ -580,6 +593,70 @@ func extractIdentifier(s string) string {
 		break
 	}
 	return result.String()
+}
+
+// sideEffectFuncs lists function name prefixes (uppercased) that indicate side effects.
+var sideEffectFuncs = []string{
+	"NEXTVAL(",
+	"SETVAL(",
+	"CURRVAL(",
+	"SET_CONFIG(",
+	"PG_ADVISORY_LOCK(",
+	"PG_ADVISORY_XACT_LOCK(",
+	"PG_ADVISORY_UNLOCK(",
+	"PG_ADVISORY_UNLOCK_ALL(",
+	"PG_TRY_ADVISORY_LOCK(",
+	"PG_TRY_ADVISORY_XACT_LOCK(",
+	"LO_CREATE(",
+	"LO_UNLINK(",
+	"PG_NOTIFY(",
+	"TXID_CURRENT(",
+}
+
+// hasSideEffectFunc checks if an uppercased query contains a known side-effectful function call.
+func hasSideEffectFunc(upperQuery string) bool {
+	for _, fn := range sideEffectFuncs {
+		if strings.Contains(upperQuery, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// lockingClauses lists locking clause patterns (uppercased) to check at word boundaries.
+var lockingClauses = []string{
+	"FOR UPDATE",
+	"FOR NO KEY UPDATE",
+	"FOR SHARE",
+	"FOR KEY SHARE",
+}
+
+// isSideEffectfulSelect checks if a SELECT statement contains locking clauses or
+// side-effectful function calls. String literals are stripped first to avoid false positives.
+func isSideEffectfulSelect(query string) bool {
+	upper := strings.ToUpper(stripStringLiterals(query))
+
+	// Check for locking clauses
+	for _, clause := range lockingClauses {
+		idx := strings.Index(upper, clause)
+		if idx >= 0 {
+			// Check word boundary before
+			if idx == 0 || upper[idx-1] == ' ' || upper[idx-1] == '\n' || upper[idx-1] == '\t' || upper[idx-1] == ')' {
+				end := idx + len(clause)
+				// Check word boundary after
+				if end >= len(upper) || upper[end] == ' ' || upper[end] == '\n' || upper[end] == '\t' || upper[end] == ';' {
+					return true
+				}
+			}
+		}
+	}
+
+	// Check for side-effectful function calls
+	if hasSideEffectFunc(upper) {
+		return true
+	}
+
+	return false
 }
 
 // stripQuotes removes surrounding double quotes from a quoted identifier.

--- a/internal/router/parser_ast.go
+++ b/internal/router/parser_ast.go
@@ -121,8 +121,8 @@ func isWriteNode(node *pg_query.Node) bool {
 	case *pg_query.Node_CommentStmt:
 		return true
 	case *pg_query.Node_SelectStmt:
-		// CTE with write operations: WITH ... AS (INSERT/UPDATE/DELETE ...)
 		s := n.SelectStmt
+		// CTE with write operations: WITH ... AS (INSERT/UPDATE/DELETE ...)
 		if s.GetWithClause() != nil {
 			for _, cte := range s.GetWithClause().GetCtes() {
 				if ce := cte.GetCommonTableExpr(); ce != nil {
@@ -132,10 +132,59 @@ func isWriteNode(node *pg_query.Node) bool {
 				}
 			}
 		}
+		// Locking clause: FOR UPDATE, FOR SHARE, FOR NO KEY UPDATE, FOR KEY SHARE
+		if len(s.GetLockingClause()) > 0 {
+			return true
+		}
+		// Side-effectful function calls: nextval(), setval(), set_config(), pg_advisory_lock(), etc.
+		if hasSideEffectFuncCalls(node) {
+			return true
+		}
 		return false
 	default:
 		return false
 	}
+}
+
+// sideEffectFuncNames lists function names (lowercased) that indicate side effects in SELECT.
+var sideEffectFuncNames = map[string]bool{
+	"nextval":                    true,
+	"setval":                     true,
+	"currval":                    true,
+	"set_config":                 true,
+	"pg_advisory_lock":           true,
+	"pg_advisory_xact_lock":      true,
+	"pg_advisory_unlock":         true,
+	"pg_advisory_unlock_all":     true,
+	"pg_try_advisory_lock":       true,
+	"pg_try_advisory_xact_lock":  true,
+	"lo_create":                  true,
+	"lo_unlink":                  true,
+	"pg_notify":                  true,
+	"txid_current":               true,
+}
+
+// hasSideEffectFuncCalls walks the AST node tree looking for FuncCall nodes
+// whose function names match known side-effectful functions.
+func hasSideEffectFuncCalls(node *pg_query.Node) bool {
+	found := false
+	walkNode(node, func(n *pg_query.Node) bool {
+		if found {
+			return false
+		}
+		if fc := n.GetFuncCall(); fc != nil {
+			for _, nameNode := range fc.GetFuncname() {
+				if s := nameNode.GetString_(); s != nil {
+					if sideEffectFuncNames[strings.ToLower(s.GetSval())] {
+						found = true
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // ExtractTablesAST extracts table names from write queries using AST parsing.


### PR DESCRIPTION
## 변경 사항

- **문자열 파서** (`parser.go`):
  - `classifyFast`: SELECT에서 `FOR UPDATE`/`FOR SHARE` 및 부작용 함수 감지 시 full parser로 fallthrough
  - `Classify`: statement별 `isSideEffectfulSelect()` 체크 추가
  - `isSideEffectfulSelect()`: locking clause + 부작용 함수(nextval, setval, set_config, pg_advisory_lock 등) 감지

- **AST 파서** (`parser_ast.go`):
  - `isWriteNode`: SelectStmt의 `LockingClause` 감지 추가
  - `hasSideEffectFuncCalls()`: AST 워킹으로 FuncCall 노드의 부작용 함수명 매칭

## 테스트

- [x] `go build ./...` 성공
- [ ] `SELECT ... FOR UPDATE` → writer 라우팅 확인
- [ ] `SELECT nextval('seq')` → writer 라우팅 확인
- [ ] 일반 SELECT 성능 회귀 없음

closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)