### PR TITLE
fix: medium QA findings (#233, #234, #235)

### DIFF
--- a/internal/router/parser.go
+++ b/internal/router/parser.go
@@ -57,6 +57,10 @@ func Classify(query string) QueryType {
 		if keyword == "WITH" && containsWriteKeyword(stmt) {
 			return QueryWrite
 		}
+		// Side-effectful SELECT: FOR UPDATE/SHARE, nextval(), set_config(), etc.
+		if keyword == "SELECT" && isSideEffectfulSelect(stmt) {
+			return QueryWrite
+		}
 	}
 	return QueryRead
 }
@@ -102,6 +106,15 @@ func classifyFast(query string) (QueryType, bool) {
 	}
 	if kw == "WITH" {
 		return 0, false // CTE needs full parser
+	}
+	if kw == "SELECT" {
+		// Check for side-effectful patterns that need full analysis
+		upper := strings.ToUpper(query)
+		if strings.Contains(upper, "FOR UPDATE") || strings.Contains(upper, "FOR SHARE") ||
+			strings.Contains(upper, "FOR NO KEY UPDATE") || strings.Contains(upper, "FOR KEY SHARE") ||
+			hasSideEffectFunc(upper) {
+			return 0, false // need full parser
+		}
 	}
 	return QueryRead, true
 }
@@ -580,6 +593,70 @@ func extractIdentifier(s string) string {
 		break
 	}
 	return result.String()
+}
+
+// sideEffectFuncs lists function name prefixes (uppercased) that indicate side effects.
+var sideEffectFuncs = []string{
+	"NEXTVAL(",
+	"SETVAL(",
+	"CURRVAL(",
+	"SET_CONFIG(",
+	"PG_ADVISORY_LOCK(",
+	"PG_ADVISORY_XACT_LOCK(",
+	"PG_ADVISORY_UNLOCK(",
+	"PG_ADVISORY_UNLOCK_ALL(",
+	"PG_TRY_ADVISORY_LOCK(",
+	"PG_TRY_ADVISORY_XACT_LOCK(",
+	"LO_CREATE(",
+	"LO_UNLINK(",
+	"PG_NOTIFY(",
+	"TXID_CURRENT(",
+}
+
+// hasSideEffectFunc checks if an uppercased query contains a known side-effectful function call.
+func hasSideEffectFunc(upperQuery string) bool {
+	for _, fn := range sideEffectFuncs {
+		if strings.Contains(upperQuery, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// lockingClauses lists locking clause patterns (uppercased) to check at word boundaries.
+var lockingClauses = []string{
+	"FOR UPDATE",
+	"FOR NO KEY UPDATE",
+	"FOR SHARE",
+	"FOR KEY SHARE",
+}
+
+// isSideEffectfulSelect checks if a SELECT statement contains locking clauses or
+// side-effectful function calls. String literals are stripped first to avoid false positives.
+func isSideEffectfulSelect(query string) bool {
+	upper := strings.ToUpper(stripStringLiterals(query))
+
+	// Check for locking clauses
+	for _, clause := range lockingClauses {
+		idx := strings.Index(upper, clause)
+		if idx >= 0 {
+			// Check word boundary before
+			if idx == 0 || upper[idx-1] == ' ' || upper[idx-1] == '\n' || upper[idx-1] == '\t' || upper[idx-1] == ')' {
+				end := idx + len(clause)
+				// Check word boundary after
+				if end >= len(upper) || upper[end] == ' ' || upper[end] == '\n' || upper[end] == '\t' || upper[end] == ';' {
+					return true
+				}
+			}
+		}
+	}
+
+	// Check for side-effectful function calls
+	if hasSideEffectFunc(upper) {
+		return true
+	}
+
+	return false
 }
 
 // stripQuotes removes surrounding double quotes from a quoted identifier.

--- a/internal/router/parser_ast.go
+++ b/internal/router/parser_ast.go
@@ -121,8 +121,8 @@ func isWriteNode(node *pg_query.Node) bool {
 	case *pg_query.Node_CommentStmt:
 		return true
 	case *pg_query.Node_SelectStmt:
-		// CTE with write operations: WITH ... AS (INSERT/UPDATE/DELETE ...)
 		s := n.SelectStmt
+		// CTE with write operations: WITH ... AS (INSERT/UPDATE/DELETE ...)
 		if s.GetWithClause() != nil {
 			for _, cte := range s.GetWithClause().GetCtes() {
 				if ce := cte.GetCommonTableExpr(); ce != nil {
@@ -132,10 +132,59 @@ func isWriteNode(node *pg_query.Node) bool {
 				}
 			}
 		}
+		// Locking clause: FOR UPDATE, FOR SHARE, FOR NO KEY UPDATE, FOR KEY SHARE
+		if len(s.GetLockingClause()) > 0 {
+			return true
+		}
+		// Side-effectful function calls: nextval(), setval(), set_config(), pg_advisory_lock(), etc.
+		if hasSideEffectFuncCalls(node) {
+			return true
+		}
 		return false
 	default:
 		return false
 	}
+}
+
+// sideEffectFuncNames lists function names (lowercased) that indicate side effects in SELECT.
+var sideEffectFuncNames = map[string]bool{
+	"nextval":                    true,
+	"setval":                     true,
+	"currval":                    true,
+	"set_config":                 true,
+	"pg_advisory_lock":           true,
+	"pg_advisory_xact_lock":      true,
+	"pg_advisory_unlock":         true,
+	"pg_advisory_unlock_all":     true,
+	"pg_try_advisory_lock":       true,
+	"pg_try_advisory_xact_lock":  true,
+	"lo_create":                  true,
+	"lo_unlink":                  true,
+	"pg_notify":                  true,
+	"txid_current":               true,
+}
+
+// hasSideEffectFuncCalls walks the AST node tree looking for FuncCall nodes
+// whose function names match known side-effectful functions.
+func hasSideEffectFuncCalls(node *pg_query.Node) bool {
+	found := false
+	walkNode(node, func(n *pg_query.Node) bool {
+		if found {
+			return false
+		}
+		if fc := n.GetFuncCall(); fc != nil {
+			for _, nameNode := range fc.GetFuncname() {
+				if s := nameNode.GetString_(); s != nil {
+					if sideEffectFuncNames[strings.ToLower(s.GetSval())] {
+						found = true
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // ExtractTablesAST extracts table names from write queries using AST parsing.


### PR DESCRIPTION
## 변경 사항

### #233: Extended/multiplex 경로 query timeout 적용
- Parse에서 query 텍스트 저장 → Sync에서 per-query hint 추출
- `executeSynthesizedQuery`, `handleSynthesizedRead`에 timer 적용
- Multiplex 경로의 writer/reader/fallback 모두 timeout 적용

### #234: Data API defaultDB hot-reload 반영
- `defaultDB string` → `defaultDBFn func() string`으로 변경
- 매 요청마다 `srv.DefaultDBName` 함수 호출로 최신값 획득

### #235: Per-database config validation 추가
- `databases.*.pool.*` 설정에 유효성 검사 추가 (max_connections >= 1, min >= 0, 음수 timeout 방지)
- Top-level timeout 음수 검증 추가

## 테스트

- [x] `go build ./...` 성공
- [ ] Extended query에서 `/* timeout:5s */` hint 적용 확인
- [ ] Multiplex synthesized 경로에서 timeout 적용 확인
- [ ] Config reload 후 Data API의 기본 DB 변경 확인
- [ ] 음수 pool 설정 시 config load 에러 확인

closes #233
closes #234
closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)