### PR TITLE
fix: QA9 pool mutex 블로킹, auth timing attack, extIsWrite 미초기화 (#262, #263, #264)

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -305,9 +305,9 @@ func (p *Pool) StartHealthCheck(ctx context.Context, interval time.Duration) {
 
 func (p *Pool) healthCheck() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	if p.closed {
+		p.mu.Unlock()
 		return
 	}
 
@@ -323,14 +323,27 @@ func (p *Pool) healthCheck() {
 	}
 	p.idle = alive
 
-	// Replenish to min connections
+	// Replenish to min connections — unlock during dial to avoid
+	// blocking all pool operations behind network I/O.
 	for p.numOpen < p.cfg.MinConnections {
+		p.numOpen++ // reserve slot
+		p.mu.Unlock()
+
 		conn, err := p.newConn()
+
+		p.mu.Lock()
 		if err != nil {
+			p.numOpen-- // release reserved slot
 			slog.Error("healthcheck: replenish connection", "error", err)
 			break
 		}
+		if p.closed {
+			p.numOpen--
+			p.mu.Unlock()
+			conn.Close()
+			return
+		}
 		p.idle = append(p.idle, conn)
-		p.numOpen++
 	}
+	p.mu.Unlock()
 }

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -105,7 +106,7 @@ func (s *Server) frontendAuth(clientConn net.Conn, username string, proxyPID, pr
 	clientHash := strings.TrimRight(string(msg.Payload), "\x00")
 	expectedHash := pgMD5Password(username, password, salt)
 
-	if clientHash != expectedHash {
+	if subtle.ConstantTimeCompare([]byte(clientHash), []byte(expectedHash)) != 1 {
 		s.sendError(clientConn, "password authentication failed for user \""+username+"\"")
 		return fmt.Errorf("MD5 password mismatch for user %q", username)
 	}

--- a/internal/proxy/query.go
+++ b/internal/proxy/query.go
@@ -633,6 +633,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 					extBuf = extBuf[:0]
 					extRoute = router.RouteReader
 					extTxStart, extTxEnd = false, false
+					extIsWrite = false
 					muxBindDetail = nil
 					continue
 				}


### PR DESCRIPTION
## Summary
- **#262**: `healthCheck` replenish 루프에서 mutex 해제 후 dial하여 pool 전체 블로킹 방지 (Acquire와 동일한 패턴)
- **#263**: MD5 인증 비교를 `subtle.ConstantTimeCompare`로 교체하여 timing side-channel 방지
- **#264**: multiplex synthesis 실패 후 `extIsWrite = false` 초기화 누락 수정 (다음 배치 read-only 오분류 방지)

## Test plan
- [x] `go test ./internal/...` 15/15 pass
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `/simplify` 코드 리뷰 통과 — 3개 에이전트 (reuse, quality, efficiency) 모두 clean

Closes #262, Closes #263, Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)