### PR TITLE
fix: golangci-lint 실패 — unused 함수 제거, empty branch 수정 (#266)

### DIFF
--- a/internal/dataapi/handler.go
+++ b/internal/dataapi/handler.go
@@ -765,13 +765,6 @@ func (s *Server) redactSQLForLog(sql string) string {
 	return redact.ForLog(sql, s.redactPolicy())
 }
 
-// truncateSQL returns the first 100 characters of a SQL statement for span attributes.
-func truncateSQL(sql string) string {
-	if len(sql) > 100 {
-		return sql[:100]
-	}
-	return sql
-}
 
 func extractBearerToken(r *http.Request) string {
 	auth := r.Header.Get("Authorization")

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -27,13 +27,6 @@ func (s *Server) sendReadyForQuery(conn net.Conn, inTransaction bool) {
 	_ = protocol.WriteMessage(conn, protocol.MsgReadyForQuery, []byte{status})
 }
 
-// truncateStr truncates a string to maxLen characters.
-func truncateStr(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
-}
 
 func (s *Server) sendError(conn net.Conn, msg string) {
 	var payload []byte
@@ -180,13 +173,6 @@ func (s *Server) extractQueryTablesParsed(query string, pq *router.ParsedQuery) 
 	return s.extractQueryTables(query)
 }
 
-// truncateSQL returns the first 100 characters of a SQL statement for span attributes.
-func truncateSQL(sql string) string {
-	if len(sql) > 100 {
-		return sql[:100]
-	}
-	return sql
-}
 
 // redactPolicy returns the current SQL redaction policy from config.
 func (s *Server) redactPolicy() redact.Policy {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -101,9 +101,6 @@ func TestSQL_SameStructureSameFingerprint(t *testing.T) {
 }
 
 func TestSQL_EmptyQuery(t *testing.T) {
-	got := SQL("", PolicyLiterals)
 	// Empty query should not panic
-	if got == "" {
-		// Acceptable — empty in, empty out (or fallback result)
-	}
+	_ = SQL("", PolicyLiterals)
 }


### PR DESCRIPTION
## Summary
- `truncateStr`, `truncateSQL` 미사용 함수 제거 (SQL redaction 도입으로 대체됨)
- `redact_test.go` empty branch → `_ = SQL(...)` 호출로 변경 (SA9003)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/...` 15/15 pass

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)