### PR TITLE
fix: golangci-lint ineffassign — return 전 boundReaderAddr 할당 제거

### DIFF
--- a/internal/proxy/query.go
+++ b/internal/proxy/query.go
@@ -701,7 +701,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 						extSpan.End()
 						slog.Error("forward ext batch to bound reader", "error", err)
 						boundReaderPool.Discard(boundReader)
-						boundReader, boundReaderPool, boundReaderAddr = nil, nil, ""
+						boundReader, boundReaderPool = nil, nil
 						return
 					}
 					if err := s.relayUntilReady(clientConn, boundReader); err != nil {
@@ -715,7 +715,7 @@ func (s *Server) relayQueries(ctx context.Context, clientConn net.Conn, session 
 						extSpan.End()
 						slog.Error("relay bound reader response", "error", err)
 						boundReaderPool.Discard(boundReader)
-						boundReader, boundReaderPool, boundReaderAddr = nil, nil, ""
+						boundReader, boundReaderPool = nil, nil
 						return
 					}
 					if stopTimer != nil {


### PR DESCRIPTION
## 변경 사항
- `internal/proxy/query.go`에서 `return` 직전 무의미한 `boundReaderAddr = ""` 할당 2건 제거
- golangci-lint `ineffassign` 규칙 위반 수정

## 테스트
- `golangci-lint run ./...` 통과

closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)